### PR TITLE
refactor: extract feature-specific modules

### DIFF
--- a/app-expo/app/(tabs)/map.tsx
+++ b/app-expo/app/(tabs)/map.tsx
@@ -23,111 +23,17 @@ import { useBlurModal } from "@/hooks/useBlurModal";
 import { Card } from "@/components/Card";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { ImageCardGrid } from "@/components/ImageCardGrid";
+import {
+        ActiveBid,
+        Review,
+        mockActiveBids,
+        mockReviews,
+        mockBidHistory,
+} from "@/features/map/constants";
+import { getBidStatusColor, getBidStatusText } from "@/features/map/utils";
 
 const { width, height } = Dimensions.get("window");
 
-interface ActiveBid {
-	placeId: string;
-	placeName: string;
-	totalAmount: number;
-	remainingDays: number;
-	latitude: number;
-	longitude: number;
-	imageUrl: string;
-	rating: number;
-	reviewCount: number;
-}
-
-interface Review {
-	id: string;
-	dishName: string;
-	imageUrl: string;
-	rating: number;
-	reviewCount: number;
-	price: number;
-}
-
-// Mock data for active bids
-const mockActiveBids: ActiveBid[] = [
-	{
-		placeId: "place_1",
-		placeName: "Bella Vista Restaurant",
-		totalAmount: 15000,
-		remainingDays: 12,
-		latitude: 35.6762,
-		longitude: 139.6503,
-		imageUrl: "https://images.pexels.com/photos/262978/pexels-photo-262978.jpeg?auto=compress&cs=tinysrgb&w=400",
-		rating: 4.5,
-		reviewCount: 127,
-	},
-	{
-		placeId: "place_2",
-		placeName: "Tokyo Ramen House",
-		totalAmount: 28000,
-		remainingDays: 8,
-		latitude: 35.658,
-		longitude: 139.7016,
-		imageUrl: "https://images.pexels.com/photos/1640777/pexels-photo-1640777.jpeg?auto=compress&cs=tinysrgb&w=400",
-		rating: 4.2,
-		reviewCount: 89,
-	},
-	{
-		placeId: "place_3",
-		placeName: "Sushi Zen",
-		totalAmount: 67000,
-		remainingDays: 5,
-		latitude: 35.6896,
-		longitude: 139.7006,
-		imageUrl: "https://images.pexels.com/photos/1640772/pexels-photo-1640772.jpeg?auto=compress&cs=tinysrgb&w=400",
-		rating: 4.8,
-		reviewCount: 203,
-	},
-];
-
-// Mock reviews data
-const mockReviews: Review[] = [
-	{
-		id: "1",
-		dishName: "Truffle Pasta",
-		imageUrl: "https://images.pexels.com/photos/4518843/pexels-photo-4518843.jpeg?auto=compress&cs=tinysrgb&w=300",
-		rating: 4.5,
-		reviewCount: 23,
-		price: 2800,
-	},
-	{
-		id: "2",
-		dishName: "Wagyu Steak",
-		imageUrl: "https://images.pexels.com/photos/3535383/pexels-photo-3535383.jpeg?auto=compress&cs=tinysrgb&w=300",
-		rating: 4.8,
-		reviewCount: 45,
-		price: 5200,
-	},
-];
-
-// Mock data for bid history
-const mockBidHistory = [
-	{
-		id: "1",
-		amount: 15000,
-		status: "active",
-		date: "2024-01-15",
-		remainingDays: 12,
-	},
-	{
-		id: "2",
-		amount: 8000,
-		status: "completed",
-		date: "2024-01-10",
-		remainingDays: 0,
-	},
-	{
-		id: "3",
-		amount: 12000,
-		status: "refunded",
-		date: "2024-01-05",
-		remainingDays: 0,
-	},
-];
 
 export default function MapScreen() {
 	const [selectedPlace, setSelectedPlace] = useState<ActiveBid | null>(null);
@@ -178,32 +84,7 @@ export default function MapScreen() {
 		});
 	}, []);
 
-	const getBidStatusColor = (status: string): string => {
-		switch (status) {
-			case "active":
-				return "#4CAF50";
-			case "completed":
-				return "#2196F3";
-			case "refunded":
-				return "#FF9800";
-			default:
-				return "#666";
-		}
-	};
-
-	const getBidStatusText = (status: string): string => {
-		switch (status) {
-			case "active":
-				return "アクティブ";
-			case "completed":
-				return "完了";
-			case "refunded":
-				return "返金済み";
-			default:
-				return status;
-		}
-	};
-
+	
 	const handleMarkerPress = (bid: ActiveBid) => {
 		setSelectedPlace(bid);
 		openRestaurantModal();

--- a/app-expo/app/(tabs)/profile/index.tsx
+++ b/app-expo/app/(tabs)/profile/index.tsx
@@ -33,85 +33,12 @@ import { useBlurModal } from "@/hooks/useBlurModal";
 import { Card } from "@/components/Card";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { ImageCardGrid } from "@/components/ImageCardGrid";
+import { BidItem, EarningItem, mockBids, mockEarnings } from "@/features/profile/constants";
 
 const { width } = Dimensions.get("window");
 const Tab = createMaterialTopTabNavigator();
 
 type TabType = "posts" | "saved" | "liked" | "wallet";
-
-interface BidItem {
-	id: string;
-	restaurantName: string;
-	bidAmount: number;
-	remainingDays: number;
-	status: "active" | "completed" | "refunded";
-	restaurantImageUrl: string;
-	imageUrl: string;
-}
-
-interface EarningItem {
-	id: string;
-	dishName: string;
-	earnings: number;
-	status: "paid" | "pending";
-	imageUrl: string;
-}
-
-// Mock data for bids
-const mockBids: BidItem[] = [
-	{
-		id: "1",
-		restaurantName: "Bella Vista Restaurant",
-		bidAmount: 15000,
-		remainingDays: 12,
-		status: "active",
-		restaurantImageUrl:
-			"https://images.pexels.com/photos/262978/pexels-photo-262978.jpeg?auto=compress&cs=tinysrgb&w=100&h=100",
-		imageUrl: "https://images.pexels.com/photos/262978/pexels-photo-262978.jpeg?auto=compress&cs=tinysrgb&w=300",
-	},
-	{
-		id: "2",
-		restaurantName: "Tokyo Ramen House",
-		bidAmount: 8000,
-		remainingDays: 5,
-		status: "active",
-		restaurantImageUrl:
-			"https://images.pexels.com/photos/1640777/pexels-photo-1640777.jpeg?auto=compress&cs=tinysrgb&w=100&h=100",
-		imageUrl: "https://images.pexels.com/photos/1640777/pexels-photo-1640777.jpeg?auto=compress&cs=tinysrgb&w=300",
-	},
-];
-
-// Mock data for earnings
-const mockEarnings: EarningItem[] = [
-	{
-		id: "1",
-		dishName: "Truffle Pasta",
-		earnings: 2400,
-		status: "paid",
-		imageUrl: "https://images.pexels.com/photos/4518843/pexels-photo-4518843.jpeg?auto=compress&cs=tinysrgb&w=300",
-	},
-	{
-		id: "2",
-		dishName: "Wagyu Steak",
-		earnings: 3200,
-		status: "paid",
-		imageUrl: "https://images.pexels.com/photos/3535383/pexels-photo-3535383.jpeg?auto=compress&cs=tinysrgb&w=300",
-	},
-	{
-		id: "3",
-		dishName: "Chocolate Soufflé",
-		earnings: 1800,
-		status: "pending",
-		imageUrl: "https://images.pexels.com/photos/3026804/pexels-photo-3026804.jpeg?auto=compress&cs=tinysrgb&w=300",
-	},
-	{
-		id: "4",
-		dishName: "Caesar Salad",
-		earnings: 1200,
-		status: "paid",
-		imageUrl: "https://images.pexels.com/photos/2097090/pexels-photo-2097090.jpeg?auto=compress&cs=tinysrgb&w=300",
-	},
-];
 
 function DepositsScreen() {
 	const [selectedStatuses, setSelectedStatuses] = useState<string[]>(["active", "completed", "refunded"]);

--- a/app-expo/app/(tabs)/search/index.tsx
+++ b/app-expo/app/(tabs)/search/index.tsx
@@ -1,15 +1,14 @@
 import React, { useState, useEffect } from "react";
 import {
-	View,
-	Text,
-	StyleSheet,
-	ScrollView,
-	TouchableOpacity,
-	TextInput,
-	SafeAreaView,
-	ActivityIndicator,
-	FlatList,
-	PanResponder,
+        View,
+        Text,
+        StyleSheet,
+        ScrollView,
+        TouchableOpacity,
+        TextInput,
+        SafeAreaView,
+        ActivityIndicator,
+        FlatList,
 } from "react-native";
 import { Divider } from "react-native-paper";
 import {
@@ -29,79 +28,16 @@ import { SearchParams, SearchLocation, GooglePlacesPrediction } from "@/types/se
 import { useLocationSearch } from "@/hooks/useLocationSearch";
 import { useSnackbar } from "@/contexts/SnackbarProvider";
 import { Card } from "@/components/Card";
-
-const timeSlots = [
-	{ id: "morning", label: "朝食", icon: "🌅" },
-	{ id: "lunch", label: "ランチ", icon: "🌞" },
-	{ id: "dinner", label: "ディナー", icon: "🌙" },
-	{ id: "late_night", label: "夜食", icon: "🌃" },
-] as const;
-
-const sceneOptions = [
-	{ id: "solo", label: "おひとり様", icon: "👤" },
-	{ id: "date", label: "デート", icon: "💕" },
-	{ id: "group", label: "複数人と", icon: "👥" },
-	{ id: "large_group", label: "大人数", icon: "👥👥" },
-	{ id: "tourism", label: "観光", icon: "🌍" },
-] as const;
-
-const moodOptions = [
-	{ id: "hearty", label: "がっつり", icon: "🍖" },
-	{ id: "light", label: "軽めに", icon: "🥗" },
-	{ id: "sweet", label: "甘いもの", icon: "🍰" },
-	{ id: "spicy", label: "辛いもの", icon: "🌶️" },
-	{ id: "healthy", label: "ヘルシー", icon: "🥬" },
-	{ id: "junk", label: "ジャンク", icon: "🍔" },
-	{ id: "alcohol", label: "お酒メイン", icon: "🍺" },
-] as const;
-
-// Distance options in meters
-const distanceOptions = [
-	{ value: 100, label: "100m" },
-	{ value: 300, label: "300m" },
-	{ value: 500, label: "500m" },
-	{ value: 800, label: "800m" },
-	{ value: 1000, label: "1km" },
-	{ value: 2000, label: "2km" },
-	{ value: 3000, label: "3km" },
-	{ value: 5000, label: "5km" },
-	{ value: 10000, label: "10km" },
-	{ value: 15000, label: "15km" },
-	{ value: 20000, label: "20km" },
-];
-
-// Budget options in yen
-const budgetOptions = [
-	{ value: null, label: "下限なし" },
-	{ value: 1000, label: "1,000円" },
-	{ value: 2000, label: "2,000円" },
-	{ value: 3000, label: "3,000円" },
-	{ value: 4000, label: "4,000円" },
-	{ value: 5000, label: "5,000円" },
-	{ value: 6000, label: "6,000円" },
-	{ value: 7000, label: "7,000円" },
-	{ value: 8000, label: "8,000円" },
-	{ value: 9000, label: "9,000円" },
-	{ value: 10000, label: "10,000円" },
-	{ value: 15000, label: "15,000円" },
-	{ value: 20000, label: "20,000円" },
-	{ value: 30000, label: "30,000円" },
-	{ value: 40000, label: "40,000円" },
-	{ value: 50000, label: "50,000円" },
-	{ value: 60000, label: "60,000円" },
-	{ value: 80000, label: "80,000円" },
-	{ value: 100000, label: "100,000円" },
-	{ value: null, label: "上限なし" },
-];
-
-const restrictionOptions = [
-	{ id: "vegetarian", label: "ベジタリアン", icon: "🌱" },
-	{ id: "gluten_free", label: "グルテンフリー", icon: "🌾" },
-	{ id: "dairy_free", label: "乳製品不使用", icon: "🥛" },
-	{ id: "nut_allergy", label: "ナッツアレルギー", icon: "🥜" },
-	{ id: "seafood_allergy", label: "魚介アレルギー", icon: "🐟" },
-	{ id: "halal", label: "ハラール", icon: "🕌" },
-];
+import {
+        timeSlots,
+        sceneOptions,
+        moodOptions,
+        distanceOptions,
+        budgetOptions,
+        restrictionOptions,
+} from "@/features/search/constants";
+import { DistanceSlider } from "@/features/search/components/DistanceSlider";
+import { BudgetSlider } from "@/features/search/components/BudgetSlider";
 
 export default function SearchScreen() {
 	const [location, setLocation] = useState<SearchLocation | null>(null);
@@ -208,104 +144,6 @@ export default function SearchScreen() {
 		} finally {
 			setIsSearching(false);
 		}
-	};
-
-	// Distance slider component
-	const DistanceSlider = () => {
-		const currentIndex = distanceOptions.findIndex((option) => option.value === distance);
-		const sliderWidth = 280;
-		const thumbWidth = 24;
-		const trackWidth = sliderWidth - thumbWidth;
-		const thumbPosition = (currentIndex / (distanceOptions.length - 1)) * trackWidth;
-
-		const panResponder = PanResponder.create({
-			onStartShouldSetPanResponder: () => true,
-			onMoveShouldSetPanResponder: () => true,
-			onPanResponderMove: (evt, gestureState) => {
-				const newPosition = Math.max(0, Math.min(trackWidth, gestureState.moveX - 50));
-				const newIndex = Math.round((newPosition / trackWidth) * (distanceOptions.length - 1));
-				if (newIndex !== currentIndex && newIndex >= 0 && newIndex < distanceOptions.length) {
-					setDistance(distanceOptions[newIndex].value);
-				}
-			},
-		});
-
-		return (
-			<View style={styles.sliderContainer}>
-				<View style={styles.sliderTrack}>
-					<View style={[styles.sliderThumb, { left: thumbPosition }]} {...panResponder.panHandlers} />
-				</View>
-				<View style={styles.sliderLabels}>
-					<Text style={styles.sliderLabelLeft}>近い</Text>
-					<Text style={styles.sliderLabelRight}>遠い</Text>
-				</View>
-			</View>
-		);
-	};
-
-	// Budget range slider component
-	const BudgetSlider = () => {
-		const minIndex = budgetMin === null ? 0 : budgetOptions.findIndex((option) => option.value === budgetMin);
-		const maxIndex =
-			budgetMax === null ? budgetOptions.length - 1 : budgetOptions.findIndex((option) => option.value === budgetMax);
-
-		const sliderWidth = 280;
-		const thumbWidth = 24;
-		const trackWidth = sliderWidth - thumbWidth;
-
-		const minThumbPosition = (minIndex / (budgetOptions.length - 1)) * trackWidth;
-		const maxThumbPosition = (maxIndex / (budgetOptions.length - 1)) * trackWidth;
-
-		const createPanResponder = (isMin: boolean) =>
-			PanResponder.create({
-				onStartShouldSetPanResponder: () => true,
-				onMoveShouldSetPanResponder: () => true,
-				onPanResponderMove: (evt, gestureState) => {
-					const newPosition = Math.max(0, Math.min(trackWidth, gestureState.moveX - 50));
-					const newIndex = Math.round((newPosition / trackWidth) * (budgetOptions.length - 1));
-
-					if (isMin) {
-						if (newIndex <= maxIndex && newIndex >= 0) {
-							setBudgetMin(budgetOptions[newIndex].value);
-						}
-					} else {
-						if (newIndex >= minIndex && newIndex < budgetOptions.length) {
-							setBudgetMax(budgetOptions[newIndex].value);
-						}
-					}
-				},
-			});
-
-		const minPanResponder = createPanResponder(true);
-		const maxPanResponder = createPanResponder(false);
-
-		return (
-			<View style={styles.sliderContainer}>
-				<View style={styles.sliderTrack}>
-					<View
-						style={[
-							styles.rangeTrack,
-							{
-								left: minThumbPosition,
-								width: maxThumbPosition - minThumbPosition + thumbWidth,
-							},
-						]}
-					/>
-					<View
-						style={[styles.sliderThumb, styles.rangeThumbMin, { left: minThumbPosition }]}
-						{...minPanResponder.panHandlers}
-					/>
-					<View
-						style={[styles.sliderThumb, styles.rangeThumbMax, { left: maxThumbPosition }]}
-						{...maxPanResponder.panHandlers}
-					/>
-				</View>
-				<View style={styles.sliderLabels}>
-					<Text style={styles.sliderLabelLeft}>安い</Text>
-					<Text style={styles.sliderLabelRight}>高い</Text>
-				</View>
-			</View>
-		);
 	};
 
 	const formatBudgetRange = () => {
@@ -453,7 +291,7 @@ export default function SearchScreen() {
 								<Text style={styles.sliderValue}>
 									{distanceOptions.find((option) => option.value === distance)?.label}
 								</Text>
-								<DistanceSlider />
+                                                                <DistanceSlider distance={distance} setDistance={setDistance} />
 							</View>
 						</Card>
 
@@ -465,7 +303,12 @@ export default function SearchScreen() {
 							</View>
 							<View style={styles.sliderSection}>
 								<Text style={styles.sliderValue}>{formatBudgetRange()}</Text>
-								<BudgetSlider />
+                                                                <BudgetSlider
+                                                                        budgetMin={budgetMin}
+                                                                        budgetMax={budgetMax}
+                                                                        setBudgetMin={setBudgetMin}
+                                                                        setBudgetMax={setBudgetMax}
+                                                                />
 							</View>
 						</Card>
 

--- a/app-expo/app/(tabs)/search/result.tsx
+++ b/app-expo/app/(tabs)/search/result.tsx
@@ -1,40 +1,23 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { View, Text, StyleSheet, Modal, TouchableOpacity, SafeAreaView } from "react-native";
 import { X, RotateCcw, Search } from "lucide-react-native";
-import { router, useLocalSearchParams } from "expo-router";
+import { useLocalSearchParams } from "expo-router";
 import FoodContentFeed from "@/components/FoodContentFeed";
-import { useSearchStore } from "@/stores/useSearchStore";
 import FoodContentMap from "@/components/FoodContentMap";
 import { LinearGradient } from "expo-linear-gradient";
+import { useSearchResult } from "@/features/search/hooks/useSearchResult";
 
 export default function ResultScreen() {
-	const { topicId } = useLocalSearchParams<{
-		topicId: string;
-	}>();
+        const { topicId } = useLocalSearchParams<{ topicId: string }>();
 
-	const [currentIndex, setCurrentIndex] = useState(0);
-	const [showCompletionModal, setShowCompletionModal] = useState(false);
-	const dishes = useSearchStore((state) => state.dishesMap[topicId] || []);
-
-	const handleIndexChange = (index: number) => {
-		setCurrentIndex(index);
-
-		// Show completion modal when reaching the last item
-		// if (index >= dishes.length - 1) {
-		//   setTimeout(() => {
-		//     setShowCompletionModal(true);
-		//   }, 1000);
-		// }
-	};
-
-	const handleClose = () => {
-		router.back();
-	};
-
-	const handleReturnToCards = () => {
-		setShowCompletionModal(false);
-		router.back();
-	};
+        const {
+                currentIndex,
+                showCompletionModal,
+                dishes,
+                handleIndexChange,
+                handleClose,
+                handleReturnToCards,
+        } = useSearchResult(topicId as string);
 
 	return (
 		<LinearGradient colors={["#FFFFFF", "#F8F9FA"]} style={styles.container}>

--- a/app-expo/features/map/constants.ts
+++ b/app-expo/features/map/constants.ts
@@ -1,0 +1,85 @@
+// Data models and mock datasets for the map feature
+export interface ActiveBid {
+        placeId: string;
+        placeName: string;
+        totalAmount: number;
+        remainingDays: number;
+        latitude: number;
+        longitude: number;
+        imageUrl: string;
+        rating: number;
+        reviewCount: number;
+}
+
+export interface Review {
+        id: string;
+        dishName: string;
+        imageUrl: string;
+        rating: number;
+        reviewCount: number;
+        price: number;
+}
+
+// Mock data for active bids
+export const mockActiveBids: ActiveBid[] = [
+        {
+                placeId: "place_1",
+                placeName: "Bella Vista Restaurant",
+                totalAmount: 15000,
+                remainingDays: 12,
+                latitude: 35.6762,
+                longitude: 139.6503,
+                imageUrl: "https://images.pexels.com/photos/262978/pexels-photo-262978.jpeg?auto=compress&cs=tinysrgb&w=400",
+                rating: 4.5,
+                reviewCount: 127,
+        },
+        {
+                placeId: "place_2",
+                placeName: "Tokyo Ramen House",
+                totalAmount: 28000,
+                remainingDays: 8,
+                latitude: 35.658,
+                longitude: 139.7016,
+                imageUrl: "https://images.pexels.com/photos/1640777/pexels-photo-1640777.jpeg?auto=compress&cs=tinysrgb&w=400",
+                rating: 4.2,
+                reviewCount: 89,
+        },
+        {
+                placeId: "place_3",
+                placeName: "Sushi Zen",
+                totalAmount: 67000,
+                remainingDays: 5,
+                latitude: 35.6896,
+                longitude: 139.7006,
+                imageUrl: "https://images.pexels.com/photos/1640772/pexels-photo-1640772.jpeg?auto=compress&cs=tinysrgb&w=400",
+                rating: 4.8,
+                reviewCount: 203,
+        },
+];
+
+// Mock reviews data
+export const mockReviews: Review[] = [
+        {
+                id: "1",
+                dishName: "Truffle Pasta",
+                imageUrl: "https://images.pexels.com/photos/4518843/pexels-photo-4518843.jpeg?auto=compress&cs=tinysrgb&w=300",
+                rating: 4.5,
+                reviewCount: 23,
+                price: 2800,
+        },
+        {
+                id: "2",
+                dishName: "Wagyu Steak",
+                imageUrl: "https://images.pexels.com/photos/3535383/pexels-photo-3535383.jpeg?auto=compress&cs=tinysrgb&w=300",
+                rating: 4.8,
+                reviewCount: 45,
+                price: 5200,
+        },
+];
+
+// Mock data for bid history
+export const mockBidHistory = [
+        { id: "1", amount: 15000, status: "active", date: "2024-01-15", remainingDays: 12 },
+        { id: "2", amount: 8000, status: "completed", date: "2024-01-10", remainingDays: 0 },
+        { id: "3", amount: 12000, status: "refunded", date: "2024-01-05", remainingDays: 0 },
+];

--- a/app-expo/features/map/utils.ts
+++ b/app-expo/features/map/utils.ts
@@ -1,0 +1,26 @@
+// Utility helpers for bid status presentation
+export const getBidStatusColor = (status: string): string => {
+        switch (status) {
+                case "active":
+                        return "#4CAF50";
+                case "completed":
+                        return "#2196F3";
+                case "refunded":
+                        return "#FF9800";
+                default:
+                        return "#666";
+        }
+};
+
+export const getBidStatusText = (status: string): string => {
+        switch (status) {
+                case "active":
+                        return "アクティブ";
+                case "completed":
+                        return "完了";
+                case "refunded":
+                        return "返金済み";
+                default:
+                        return status;
+        }
+};

--- a/app-expo/features/profile/constants.ts
+++ b/app-expo/features/profile/constants.ts
@@ -1,0 +1,74 @@
+// Mock datasets used within the profile feature
+export interface BidItem {
+        id: string;
+        restaurantName: string;
+        bidAmount: number;
+        remainingDays: number;
+        status: "active" | "completed" | "refunded";
+        restaurantImageUrl: string;
+        imageUrl: string;
+}
+
+export interface EarningItem {
+        id: string;
+        dishName: string;
+        earnings: number;
+        status: "paid" | "pending";
+        imageUrl: string;
+}
+
+// Mock data for bids
+export const mockBids: BidItem[] = [
+        {
+                id: "1",
+                restaurantName: "Bella Vista Restaurant",
+                bidAmount: 15000,
+                remainingDays: 12,
+                status: "active",
+                restaurantImageUrl:
+                        "https://images.pexels.com/photos/262978/pexels-photo-262978.jpeg?auto=compress&cs=tinysrgb&w=100&h=100",
+                imageUrl: "https://images.pexels.com/photos/262978/pexels-photo-262978.jpeg?auto=compress&cs=tinysrgb&w=300",
+        },
+        {
+                id: "2",
+                restaurantName: "Tokyo Ramen House",
+                bidAmount: 8000,
+                remainingDays: 5,
+                status: "active",
+                restaurantImageUrl:
+                        "https://images.pexels.com/photos/1640777/pexels-photo-1640777.jpeg?auto=compress&cs=tinysrgb&w=100&h=100",
+                imageUrl: "https://images.pexels.com/photos/1640777/pexels-photo-1640777.jpeg?auto=compress&cs=tinysrgb&w=300",
+        },
+];
+
+// Mock data for earnings
+export const mockEarnings: EarningItem[] = [
+        {
+                id: "1",
+                dishName: "Truffle Pasta",
+                earnings: 2400,
+                status: "paid",
+                imageUrl: "https://images.pexels.com/photos/4518843/pexels-photo-4518843.jpeg?auto=compress&cs=tinysrgb&w=300",
+        },
+        {
+                id: "2",
+                dishName: "Wagyu Steak",
+                earnings: 3200,
+                status: "paid",
+                imageUrl: "https://images.pexels.com/photos/3535383/pexels-photo-3535383.jpeg?auto=compress&cs=tinysrgb&w=300",
+        },
+        {
+                id: "3",
+                dishName: "Chocolate Soufflé",
+                earnings: 1800,
+                status: "pending",
+                imageUrl: "https://images.pexels.com/photos/3026804/pexels-photo-3026804.jpeg?auto=compress&cs=tinysrgb&w=300",
+        },
+        {
+                id: "4",
+                dishName: "Caesar Salad",
+                earnings: 1200,
+                status: "paid",
+                imageUrl: "https://images.pexels.com/photos/2097090/pexels-photo-2097090.jpeg?auto=compress&cs=tinysrgb&w=300",
+        },
+];

--- a/app-expo/features/search/components/BudgetSlider.tsx
+++ b/app-expo/features/search/components/BudgetSlider.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { View, Text, PanResponder } from "react-native";
+import { budgetOptions } from "@/features/search/constants";
+
+// Slider component to choose budget range
+export function BudgetSlider({
+        budgetMin,
+        budgetMax,
+        setBudgetMin,
+        setBudgetMax,
+}: {
+        budgetMin: number | null;
+        budgetMax: number | null;
+        setBudgetMin: (value: number | null) => void;
+        setBudgetMax: (value: number | null) => void;
+}) {
+        const minIndex = budgetMin === null ? 0 : budgetOptions.findIndex((o) => o.value === budgetMin);
+        const maxIndex = budgetMax === null ? budgetOptions.length - 1 : budgetOptions.findIndex((o) => o.value === budgetMax);
+
+        const sliderWidth = 280;
+        const thumbWidth = 24;
+        const trackWidth = sliderWidth - thumbWidth;
+
+        const minThumbPosition = (minIndex / (budgetOptions.length - 1)) * trackWidth;
+        const maxThumbPosition = (maxIndex / (budgetOptions.length - 1)) * trackWidth;
+
+        const createPanResponder = (isMin: boolean) =>
+                PanResponder.create({
+                        onStartShouldSetPanResponder: () => true,
+                        onMoveShouldSetPanResponder: () => true,
+                        onPanResponderMove: (evt, gestureState) => {
+                                const newPosition = Math.max(0, Math.min(trackWidth, gestureState.moveX - 50));
+                                const newIndex = Math.round((newPosition / trackWidth) * (budgetOptions.length - 1));
+
+                                if (isMin) {
+                                        if (newIndex <= maxIndex && newIndex >= 0) {
+                                                setBudgetMin(budgetOptions[newIndex].value);
+                                        }
+                                } else {
+                                        if (newIndex >= minIndex && newIndex < budgetOptions.length) {
+                                                setBudgetMax(budgetOptions[newIndex].value);
+                                        }
+                                }
+                        },
+                });
+
+        const minPanResponder = createPanResponder(true);
+        const maxPanResponder = createPanResponder(false);
+
+        return (
+                <View style={styles.sliderContainer}>
+                        <View style={styles.sliderTrack}>
+                                <View
+                                        style={[
+                                                styles.rangeTrack,
+                                                {
+                                                        left: minThumbPosition,
+                                                        width: maxThumbPosition - minThumbPosition + thumbWidth,
+                                                },
+                                        ]}
+                                />
+                                <View
+                                        style={[styles.sliderThumb, styles.rangeThumbMin, { left: minThumbPosition }]}
+                                        {...minPanResponder.panHandlers}
+                                />
+                                <View
+                                        style={[styles.sliderThumb, styles.rangeThumbMax, { left: maxThumbPosition }]}
+                                        {...maxPanResponder.panHandlers}
+                                />
+                        </View>
+                        <View style={styles.sliderLabels}>
+                                <Text style={styles.sliderLabelLeft}>安い</Text>
+                                <Text style={styles.sliderLabelRight}>高い</Text>
+                        </View>
+                </View>
+        );
+}
+
+// Styles mirror the ones in the original screen
+const styles = {
+        sliderContainer: {
+                width: 300,
+                justifyContent: "center",
+        },
+        sliderTrack: {
+                height: 6,
+                backgroundColor: "#E5E7EB",
+                borderRadius: 3,
+                position: "relative",
+                marginHorizontal: 16,
+        },
+        sliderThumb: {
+                position: "absolute",
+                width: 28,
+                height: 28,
+                backgroundColor: "#5EA2FF",
+                borderRadius: 14,
+                top: -11,
+                borderWidth: 3,
+                borderColor: "#FFFFFF",
+                shadowColor: "#000",
+                shadowOffset: { width: 0, height: 4 },
+                shadowOpacity: 0.15,
+                shadowRadius: 8,
+                elevation: 6,
+        },
+        rangeTrack: {
+                position: "absolute",
+                height: 6,
+                backgroundColor: "#5EA2FF",
+                borderRadius: 3,
+                top: 0,
+        },
+        rangeThumbMin: {
+                backgroundColor: "#5EA2FF",
+        },
+        rangeThumbMax: {
+                backgroundColor: "#5EA2FF",
+        },
+        sliderLabels: {
+                flexDirection: "row",
+                justifyContent: "space-between",
+                marginTop: 12,
+                paddingHorizontal: 16,
+        },
+        sliderLabelLeft: {
+                fontSize: 13,
+                color: "#6B7280",
+                fontWeight: "500",
+        },
+        sliderLabelRight: {
+                fontSize: 13,
+                color: "#6B7280",
+                fontWeight: "500",
+        },
+} as const;

--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { View, Text, PanResponder } from "react-native";
+import { distanceOptions } from "@/features/search/constants";
+
+// Slider component to choose search distance
+export function DistanceSlider({
+        distance,
+        setDistance,
+}: {
+        distance: number;
+        setDistance: (value: number) => void;
+}) {
+        const currentIndex = distanceOptions.findIndex((option) => option.value === distance);
+        const sliderWidth = 280;
+        const thumbWidth = 24;
+        const trackWidth = sliderWidth - thumbWidth;
+        const thumbPosition = (currentIndex / (distanceOptions.length - 1)) * trackWidth;
+
+        const panResponder = PanResponder.create({
+                onStartShouldSetPanResponder: () => true,
+                onMoveShouldSetPanResponder: () => true,
+                onPanResponderMove: (evt, gestureState) => {
+                        const newPosition = Math.max(0, Math.min(trackWidth, gestureState.moveX - 50));
+                        const newIndex = Math.round((newPosition / trackWidth) * (distanceOptions.length - 1));
+                        if (newIndex !== currentIndex && newIndex >= 0 && newIndex < distanceOptions.length) {
+                                setDistance(distanceOptions[newIndex].value);
+                        }
+                },
+        });
+
+        return (
+                <View style={styles.sliderContainer}>
+                        <View style={styles.sliderTrack}>
+                                <View style={[styles.sliderThumb, { left: thumbPosition }]} {...panResponder.panHandlers} />
+                        </View>
+                        <View style={styles.sliderLabels}>
+                                <Text style={styles.sliderLabelLeft}>近い</Text>
+                                <Text style={styles.sliderLabelRight}>遠い</Text>
+                        </View>
+                </View>
+        );
+}
+
+// Styles mirror the ones in the original screen
+const styles = {
+        sliderContainer: {
+                width: 300,
+                justifyContent: "center",
+        },
+        sliderTrack: {
+                height: 6,
+                backgroundColor: "#E5E7EB",
+                borderRadius: 3,
+                position: "relative",
+                marginHorizontal: 16,
+        },
+        sliderThumb: {
+                position: "absolute",
+                width: 28,
+                height: 28,
+                backgroundColor: "#5EA2FF",
+                borderRadius: 14,
+                top: -11,
+                borderWidth: 3,
+                borderColor: "#FFFFFF",
+                shadowColor: "#000",
+                shadowOffset: { width: 0, height: 4 },
+                shadowOpacity: 0.15,
+                shadowRadius: 8,
+                elevation: 6,
+        },
+        sliderLabels: {
+                flexDirection: "row",
+                justifyContent: "space-between",
+                marginTop: 12,
+                paddingHorizontal: 16,
+        },
+        sliderLabelLeft: {
+                fontSize: 13,
+                color: "#6B7280",
+                fontWeight: "500",
+        },
+        sliderLabelRight: {
+                fontSize: 13,
+                color: "#6B7280",
+                fontWeight: "500",
+        },
+} as const;

--- a/app-expo/features/search/constants.ts
+++ b/app-expo/features/search/constants.ts
@@ -1,0 +1,73 @@
+// Constants and option data for the search feature
+export const timeSlots = [
+        { id: "morning", label: "朝食", icon: "🌅" },
+        { id: "lunch", label: "ランチ", icon: "🌞" },
+        { id: "dinner", label: "ディナー", icon: "🌙" },
+        { id: "late_night", label: "夜食", icon: "🌃" },
+] as const;
+
+export const sceneOptions = [
+        { id: "solo", label: "おひとり様", icon: "👤" },
+        { id: "date", label: "デート", icon: "💕" },
+        { id: "group", label: "複数人と", icon: "👥" },
+        { id: "large_group", label: "大人数", icon: "👥👥" },
+        { id: "tourism", label: "観光", icon: "🌍" },
+] as const;
+
+export const moodOptions = [
+        { id: "hearty", label: "がっつり", icon: "🍖" },
+        { id: "light", label: "軽めに", icon: "🥗" },
+        { id: "sweet", label: "甘いもの", icon: "🍰" },
+        { id: "spicy", label: "辛いもの", icon: "🌶️" },
+        { id: "healthy", label: "ヘルシー", icon: "🥬" },
+        { id: "junk", label: "ジャンク", icon: "🍔" },
+        { id: "alcohol", label: "お酒メイン", icon: "🍺" },
+] as const;
+
+// Distance options in meters
+export const distanceOptions = [
+        { value: 100, label: "100m" },
+        { value: 300, label: "300m" },
+        { value: 500, label: "500m" },
+        { value: 800, label: "800m" },
+        { value: 1000, label: "1km" },
+        { value: 2000, label: "2km" },
+        { value: 3000, label: "3km" },
+        { value: 5000, label: "5km" },
+        { value: 10000, label: "10km" },
+        { value: 15000, label: "15km" },
+        { value: 20000, label: "20km" },
+];
+
+// Budget options in yen
+export const budgetOptions = [
+        { value: null, label: "下限なし" },
+        { value: 1000, label: "1,000円" },
+        { value: 2000, label: "2,000円" },
+        { value: 3000, label: "3,000円" },
+        { value: 4000, label: "4,000円" },
+        { value: 5000, label: "5,000円" },
+        { value: 6000, label: "6,000円" },
+        { value: 7000, label: "7,000円" },
+        { value: 8000, label: "8,000円" },
+        { value: 9000, label: "9,000円" },
+        { value: 10000, label: "10,000円" },
+        { value: 15000, label: "15,000円" },
+        { value: 20000, label: "20,000円" },
+        { value: 30000, label: "30,000円" },
+        { value: 40000, label: "40,000円" },
+        { value: 50000, label: "50,000円" },
+        { value: 60000, label: "60,000円" },
+        { value: 80000, label: "80,000円" },
+        { value: 100000, label: "100,000円" },
+        { value: null, label: "上限なし" },
+];
+
+export const restrictionOptions = [
+        { id: "vegetarian", label: "ベジタリアン", icon: "🌱" },
+        { id: "gluten_free", label: "グルテンフリー", icon: "🌾" },
+        { id: "dairy_free", label: "乳製品不使用", icon: "🥛" },
+        { id: "nut_allergy", label: "ナッツアレルギー", icon: "🥜" },
+        { id: "seafood_allergy", label: "魚介アレルギー", icon: "🐟" },
+        { id: "halal", label: "ハラール", icon: "🕌" },
+];

--- a/app-expo/features/search/hooks/useSearchResult.ts
+++ b/app-expo/features/search/hooks/useSearchResult.ts
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+import { router } from "expo-router";
+import { useSearchStore } from "@/stores/useSearchStore";
+
+// Encapsulates state and handlers for the search result screen
+export function useSearchResult(topicId: string) {
+        const [currentIndex, setCurrentIndex] = useState(0);
+        const [showCompletionModal, setShowCompletionModal] = useState(false);
+        const dishes = useSearchStore((state) => state.dishesMap[topicId] || []);
+
+        const handleIndexChange = (index: number) => {
+                setCurrentIndex(index);
+                // Completion modal logic preserved from original component
+        };
+
+        const handleClose = () => {
+                router.back();
+        };
+
+        const handleReturnToCards = () => {
+                setShowCompletionModal(false);
+                router.back();
+        };
+
+        return {
+                currentIndex,
+                showCompletionModal,
+                dishes,
+                handleIndexChange,
+                handleClose,
+                handleReturnToCards,
+        };
+}


### PR DESCRIPTION
## Summary
- split search options and sliders into feature modules
- centralize map mock data and helpers
- move profile mock data into feature constants

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6891cd3a4404832b96f2ac113e6c19f1