### PR TITLE
feat: add i18n strings

### DIFF
--- a/app-expo/app/(tabs)/notifications.tsx
+++ b/app-expo/app/(tabs)/notifications.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Image, SafeAreaView, Dimensions } from "react-native";
+import i18n from "@/lib/i18n";
 import { LinearGradient } from "expo-linear-gradient";
 import { Heart, MessageCircle, UserPlus, AtSign, Share, MoveHorizontal as MoreHorizontal } from "lucide-react-native";
 import { NotificationItem } from "@/types";
@@ -103,7 +104,7 @@ export default function NotificationsScreen() {
 		<SafeAreaView style={styles.container}>
 			{/* Header */}
 			<View style={styles.header}>
-				<Text style={styles.headerTitle}>通知</Text>
+                                <Text style={styles.headerTitle}>{i18n.t("Notifications.title")}</Text>
 				{unreadCount > 0 && (
 					<View style={styles.unreadBadge}>
 						<Text style={styles.unreadBadgeText}>{unreadCount}</Text>

--- a/app-expo/features/search/components/BudgetSlider.tsx
+++ b/app-expo/features/search/components/BudgetSlider.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View, Text, PanResponder } from "react-native";
 import { budgetOptions } from "@/features/search/constants";
+import i18n from "@/lib/i18n";
 
 // Slider component to choose budget range
 export function BudgetSlider({
@@ -69,12 +70,12 @@ export function BudgetSlider({
 					{...maxPanResponder.panHandlers}
 				/>
 			</View>
-			<View style={styles.sliderLabels}>
-				<Text style={styles.sliderLabelLeft}>安い</Text>
-				<Text style={styles.sliderLabelRight}>高い</Text>
-			</View>
-		</View>
-	);
+                        <View style={styles.sliderLabels}>
+                                <Text style={styles.sliderLabelLeft}>{i18n.t("Search.BudgetSlider.cheap")}</Text>
+                                <Text style={styles.sliderLabelRight}>{i18n.t("Search.BudgetSlider.expensive")}</Text>
+                        </View>
+                </View>
+        );
 }
 
 // Styles mirror the ones in the original screen

--- a/app-expo/features/search/components/DistanceSlider.tsx
+++ b/app-expo/features/search/components/DistanceSlider.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View, Text, PanResponder } from "react-native";
 import { distanceOptions } from "@/features/search/constants";
+import i18n from "@/lib/i18n";
 
 // Slider component to choose search distance
 export function DistanceSlider({ distance, setDistance }: { distance: number; setDistance: (value: number) => void }) {
@@ -27,12 +28,12 @@ export function DistanceSlider({ distance, setDistance }: { distance: number; se
 			<View style={styles.sliderTrack}>
 				<View style={[styles.sliderThumb, { left: thumbPosition }]} {...panResponder.panHandlers} />
 			</View>
-			<View style={styles.sliderLabels}>
-				<Text style={styles.sliderLabelLeft}>近い</Text>
-				<Text style={styles.sliderLabelRight}>遠い</Text>
-			</View>
-		</View>
-	);
+                        <View style={styles.sliderLabels}>
+                                <Text style={styles.sliderLabelLeft}>{i18n.t("Search.DistanceSlider.near")}</Text>
+                                <Text style={styles.sliderLabelRight}>{i18n.t("Search.DistanceSlider.far")}</Text>
+                        </View>
+                </View>
+        );
 }
 
 // Styles mirror the ones in the original screen

--- a/app-expo/features/topics/components/HideTopicModal.tsx
+++ b/app-expo/features/topics/components/HideTopicModal.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Modal, View, Text, StyleSheet, TouchableOpacity, TextInput } from "react-native";
 import { X } from "lucide-react-native";
 import { width } from "@/features/topics/constants";
+import i18n from "@/lib/i18n";
 
 interface Props {
 	visible: boolean;
@@ -17,17 +18,17 @@ export const HideTopicModal = ({ visible, onRequestClose, hideReason, setHideRea
 		<View style={styles.modalOverlay}>
 			<View style={styles.modalContainer}>
 				<View style={styles.modalHeader}>
-					<Text style={styles.modalTitle}>非表示にする</Text>
+                                        <Text style={styles.modalTitle}>{i18n.t("Topics.HideTopicModal.title")}</Text>
 					<TouchableOpacity onPress={onRequestClose}>
 						<X size={24} color="#49454F" />
 					</TouchableOpacity>
 				</View>
 
-				<Text style={styles.modalDescription}>非表示にする理由を教えてください（任意）</Text>
+                                <Text style={styles.modalDescription}>{i18n.t("Topics.HideTopicModal.description")}</Text>
 
 				<TextInput
 					style={styles.reasonInput}
-					placeholder="理由を入力してください..."
+                                        placeholder={i18n.t("Topics.HideTopicModal.placeholder")}
 					value={hideReason}
 					onChangeText={setHideReason}
 					multiline
@@ -37,16 +38,16 @@ export const HideTopicModal = ({ visible, onRequestClose, hideReason, setHideRea
 				/>
 
 				<View style={styles.modalActions}>
-					<TouchableOpacity style={styles.cancelButton} onPress={onRequestClose}>
-						<Text style={styles.cancelButtonText}>キャンセル</Text>
-					</TouchableOpacity>
-					<TouchableOpacity style={styles.confirmButton} onPress={confirmHideCard}>
-						<Text style={styles.confirmButtonText}>非表示にする</Text>
-					</TouchableOpacity>
-				</View>
-			</View>
-		</View>
-	</Modal>
+                                        <TouchableOpacity style={styles.cancelButton} onPress={onRequestClose}>
+                                                <Text style={styles.cancelButtonText}>{i18n.t("Common.cancel")}</Text>
+                                        </TouchableOpacity>
+                                        <TouchableOpacity style={styles.confirmButton} onPress={confirmHideCard}>
+                                                <Text style={styles.confirmButtonText}>{i18n.t("Topics.HideTopicModal.confirm")}</Text>
+                                        </TouchableOpacity>
+                                </View>
+                        </View>
+                </View>
+        </Modal>
 );
 
 const styles = StyleSheet.create({

--- a/app-expo/features/topics/components/TopicsError.tsx
+++ b/app-expo/features/topics/components/TopicsError.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { View, Text, StyleSheet, SafeAreaView, TouchableOpacity } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
+import i18n from "@/lib/i18n";
 
 // Error view shown when fetching topics fails
 export const TopicsError = ({ error, onBack }: { error: string; onBack: () => void }) => (
@@ -8,12 +9,12 @@ export const TopicsError = ({ error, onBack }: { error: string; onBack: () => vo
 		<SafeAreaView style={styles.errorContent}>
 			<View style={styles.errorCard}>
 				<Text style={styles.errorText}>{error}</Text>
-				<TouchableOpacity style={styles.retryButton} onPress={onBack}>
-					<Text style={styles.retryButtonText}>戻る</Text>
-				</TouchableOpacity>
-			</View>
-		</SafeAreaView>
-	</LinearGradient>
+                                <TouchableOpacity style={styles.retryButton} onPress={onBack}>
+                                        <Text style={styles.retryButtonText}>{i18n.t("Common.back")}</Text>
+                                </TouchableOpacity>
+                        </View>
+                </SafeAreaView>
+        </LinearGradient>
 );
 
 const styles = StyleSheet.create({

--- a/app-expo/features/topics/components/TopicsLoading.tsx
+++ b/app-expo/features/topics/components/TopicsLoading.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { View, Text, StyleSheet, SafeAreaView, ActivityIndicator } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { Sparkles } from "lucide-react-native";
+import i18n from "@/lib/i18n";
 
 // Loading indicator while topics are being fetched
 export const TopicsLoading = () => (
@@ -12,11 +13,11 @@ export const TopicsLoading = () => (
 					<Sparkles size={32} color="#5EA2FF" />
 				</View>
 				<ActivityIndicator size="large" color="#5EA2FF" style={styles.loadingSpinner} />
-				<Text style={styles.loadingTitle}>あなたにぴったりの料理を探しています</Text>
-				<Text style={styles.loadingSubtitle}>少々お待ちください...</Text>
-			</View>
-		</SafeAreaView>
-	</LinearGradient>
+                                <Text style={styles.loadingTitle}>{i18n.t("Topics.Loading.title")}</Text>
+                                <Text style={styles.loadingSubtitle}>{i18n.t("Topics.Loading.subtitle")}</Text>
+                        </View>
+                </SafeAreaView>
+        </LinearGradient>
 );
 
 const styles = StyleSheet.create({

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -2,10 +2,36 @@
 	"Common": {
 		"cancel": "إلغاء",
 		"ok": "موافق",
-		"goStore": "افتح متجر التطبيقات"
+		"goStore": "افتح متجر التطبيقات",
+		"back": "رجوع"
 	},
 	"Error": {
 		"maintenanceMessage": "نحن حالياً نقوم بأعمال صيانة.",
 		"unsupportedVersion": "هذا الإصدار لم يعد مدعومًا."
+	},
+	"Search": {
+		"DistanceSlider": {
+			"near": "قريب",
+			"far": "بعيد"
+		},
+		"BudgetSlider": {
+			"cheap": "رخيص",
+			"expensive": "غالي"
+		}
+	},
+	"Topics": {
+		"HideTopicModal": {
+			"title": "إخفاء",
+			"description": "أخبرنا سبب الإخفاء (اختياري)",
+			"placeholder": "أدخل السبب...",
+			"confirm": "إخفاء"
+		},
+		"Loading": {
+			"title": "نبحث عن الطبق المناسب لك",
+			"subtitle": "يرجى الانتظار..."
+		}
+	},
+	"Notifications": {
+		"title": "الإشعارات"
 	}
 }

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -2,10 +2,36 @@
 	"Common": {
 		"cancel": "Cancel",
 		"ok": "OK",
-		"goStore": "Open App Store"
+		"goStore": "Open App Store",
+		"back": "Back"
 	},
 	"Error": {
 		"maintenanceMessage": "We are currently undergoing maintenance.",
 		"unsupportedVersion": "This version is no longer supported."
+	},
+	"Search": {
+		"DistanceSlider": {
+			"near": "Near",
+			"far": "Far"
+		},
+		"BudgetSlider": {
+			"cheap": "Cheap",
+			"expensive": "Expensive"
+		}
+	},
+	"Topics": {
+		"HideTopicModal": {
+			"title": "Hide",
+			"description": "Please tell us the reason for hiding (optional)",
+			"placeholder": "Enter a reason...",
+			"confirm": "Hide"
+		},
+		"Loading": {
+			"title": "Searching for dishes perfect for you",
+			"subtitle": "Please wait a moment..."
+		}
+	},
+	"Notifications": {
+		"title": "Notifications"
 	}
 }

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -2,10 +2,36 @@
 	"Common": {
 		"cancel": "Cancelar",
 		"ok": "Aceptar",
-		"goStore": "Abrir App Store"
+		"goStore": "Abrir App Store",
+		"back": "Atrás"
 	},
 	"Error": {
 		"maintenanceMessage": "Actualmente estamos en mantenimiento.",
 		"unsupportedVersion": "Esta versión ya no es compatible."
+	},
+	"Search": {
+		"DistanceSlider": {
+			"near": "Cerca",
+			"far": "Lejos"
+		},
+		"BudgetSlider": {
+			"cheap": "Barato",
+			"expensive": "Caro"
+		}
+	},
+	"Topics": {
+		"HideTopicModal": {
+			"title": "Ocultar",
+			"description": "Dinos la razón para ocultarlo (opcional)",
+			"placeholder": "Introduce una razón...",
+			"confirm": "Ocultar"
+		},
+		"Loading": {
+			"title": "Buscando el plato perfecto para ti",
+			"subtitle": "Por favor, espera..."
+		}
+	},
+	"Notifications": {
+		"title": "Notificaciones"
 	}
 }

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -2,10 +2,36 @@
 	"Common": {
 		"cancel": "Annuler",
 		"ok": "OK",
-		"goStore": "Ouvrir l’App Store"
+		"goStore": "Ouvrir l’App Store",
+		"back": "Retour"
 	},
 	"Error": {
 		"maintenanceMessage": "Nous sommes actuellement en maintenance.",
 		"unsupportedVersion": "Cette version n'est plus prise en charge."
+	},
+	"Search": {
+		"DistanceSlider": {
+			"near": "Proche",
+			"far": "Loin"
+		},
+		"BudgetSlider": {
+			"cheap": "Bon marché",
+			"expensive": "Cher"
+		}
+	},
+	"Topics": {
+		"HideTopicModal": {
+			"title": "Masquer",
+			"description": "Veuillez indiquer la raison du masquage (facultatif)",
+			"placeholder": "Entrez une raison...",
+			"confirm": "Masquer"
+		},
+		"Loading": {
+			"title": "Nous recherchons des plats faits pour vous",
+			"subtitle": "Veuillez patienter..."
+		}
+	},
+	"Notifications": {
+		"title": "Notifications"
 	}
 }

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -2,10 +2,36 @@
 	"Common": {
 		"cancel": "रद्द करें",
 		"ok": "ओके",
-		"goStore": "ऐप स्टोर खोलें"
+		"goStore": "ऐप स्टोर खोलें",
+		"back": "वापस"
 	},
 	"Error": {
 		"maintenanceMessage": "हम वर्तमान में रखरखाव कर रहे हैं।",
 		"unsupportedVersion": "यह संस्करण अब समर्थित नहीं है।"
+	},
+	"Search": {
+		"DistanceSlider": {
+			"near": "पास",
+			"far": "दूर"
+		},
+		"BudgetSlider": {
+			"cheap": "सस्ता",
+			"expensive": "महंगा"
+		}
+	},
+	"Topics": {
+		"HideTopicModal": {
+			"title": "छिपाएँ",
+			"description": "कृपया छिपाने का कारण बताएं (वैकल्पिक)",
+			"placeholder": "कारण दर्ज करें...",
+			"confirm": "छिपाएँ"
+		},
+		"Loading": {
+			"title": "आपके लिए उपयुक्त व्यंजन खोज रहे हैं",
+			"subtitle": "कृपया प्रतीक्षा करें..."
+		}
+	},
+	"Notifications": {
+		"title": "सूचनाएँ"
 	}
 }

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -2,10 +2,36 @@
 	"Common": {
 		"cancel": "キャンセル",
 		"ok": "OK",
-		"goStore": "アプリストアを開く"
+		"goStore": "アプリストアを開く",
+		"back": "戻る"
 	},
 	"Error": {
 		"maintenanceMessage": "ただいまメンテナンス中です。",
 		"unsupportedVersion": "古いバージョンのため利用できません。"
+	},
+	"Search": {
+		"DistanceSlider": {
+			"near": "近い",
+			"far": "遠い"
+		},
+		"BudgetSlider": {
+			"cheap": "安い",
+			"expensive": "高い"
+		}
+	},
+	"Topics": {
+		"HideTopicModal": {
+			"title": "非表示にする",
+			"description": "非表示にする理由を教えてください（任意）",
+			"placeholder": "理由を入力してください...",
+			"confirm": "非表示にする"
+		},
+		"Loading": {
+			"title": "あなたにぴったりの料理を探しています",
+			"subtitle": "少々お待ちください..."
+		}
+	},
+	"Notifications": {
+		"title": "通知"
 	}
 }

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -2,10 +2,36 @@
 	"Common": {
 		"cancel": "취소",
 		"ok": "확인",
-		"goStore": "앱 스토어 열기"
+		"goStore": "앱 스토어 열기",
+		"back": "뒤로"
 	},
 	"Error": {
 		"maintenanceMessage": "현재 점검 중입니다.",
 		"unsupportedVersion": "이 버전은 더 이상 지원되지 않습니다."
+	},
+	"Search": {
+		"DistanceSlider": {
+			"near": "가까움",
+			"far": "멀리"
+		},
+		"BudgetSlider": {
+			"cheap": "저렴함",
+			"expensive": "비쌈"
+		}
+	},
+	"Topics": {
+		"HideTopicModal": {
+			"title": "숨기기",
+			"description": "숨기는 이유를 알려주세요 (선택사항)",
+			"placeholder": "이유를 입력하세요...",
+			"confirm": "숨기기"
+		},
+		"Loading": {
+			"title": "당신에게 딱 맞는 요리를 찾고 있어요",
+			"subtitle": "잠시만 기다려 주세요..."
+		}
+	},
+	"Notifications": {
+		"title": "알림"
 	}
 }

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -2,10 +2,36 @@
 	"Common": {
 		"cancel": "取消",
 		"ok": "确定",
-		"goStore": "打开应用商店"
+		"goStore": "打开应用商店",
+		"back": "返回"
 	},
 	"Error": {
 		"maintenanceMessage": "当前正在维护中。",
 		"unsupportedVersion": "此版本已不再受支持."
+	},
+	"Search": {
+		"DistanceSlider": {
+			"near": "近",
+			"far": "远"
+		},
+		"BudgetSlider": {
+			"cheap": "便宜",
+			"expensive": "昂贵"
+		}
+	},
+	"Topics": {
+		"HideTopicModal": {
+			"title": "隐藏",
+			"description": "请告诉我们隐藏的理由（可选）",
+			"placeholder": "请输入理由...",
+			"confirm": "隐藏"
+		},
+		"Loading": {
+			"title": "正在为你寻找合适的菜品",
+			"subtitle": "请稍候..."
+		}
+	},
+	"Notifications": {
+		"title": "通知"
 	}
 }


### PR DESCRIPTION
## Summary
- internationalize several React components
- expand locale dictionaries across all supported languages

## Testing
- `pnpm --filter app-expo lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm --filter app-expo typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689231fa3b6c832b827f5ba2274ac57b