### PR TITLE
feat: add i18n support for component texts

### DIFF
--- a/app-expo/components/FoodContentScreen.tsx
+++ b/app-expo/components/FoodContentScreen.tsx
@@ -5,6 +5,7 @@ import { FoodItem } from "@/types";
 import { router } from "expo-router";
 import { LinearGradient } from "expo-linear-gradient";
 import { useBlurModal } from "@/hooks/useBlurModal";
+import i18n from "@/lib/i18n";
 
 const { width, height } = Dimensions.get("window");
 
@@ -13,13 +14,21 @@ interface FoodContentScreenProps {
 }
 
 const formatLikeCount = (count: number): string => {
-	if (count >= 1000000) {
-		return (count / 1000000).toFixed(1).replace(/\.0$/, "") + "M";
-	}
-	if (count >= 1000) {
-		return (count / 1000).toFixed(1).replace(/\.0$/, "") + "K";
-	}
-	return count.toString();
+        if (count >= 1000000) {
+                return (
+                        count / 1000000
+                )
+                        .toFixed(1)
+                        .replace(/\.0$/, "") + i18n.t("FoodContentScreen.numberSuffix.million");
+        }
+        if (count >= 1000) {
+                return (
+                        count / 1000
+                )
+                        .toFixed(1)
+                        .replace(/\.0$/, "") + i18n.t("FoodContentScreen.numberSuffix.thousand");
+        }
+        return count.toString();
 };
 
 export default function FoodContentScreen({ item }: FoodContentScreenProps) {
@@ -62,14 +71,18 @@ export default function FoodContentScreen({ item }: FoodContentScreenProps) {
 		router.push("/profile?userId=creator_123");
 	};
 
-	const menuOptions = [
-		{ icon: User, label: "投稿者プロフィールへ", onPress: handleViewCreator },
-		{
-			icon: Calendar,
-			label: "予約",
-			onPress: () => console.log("Reservation"),
-		},
-	];
+        const menuOptions = [
+                {
+                        icon: User,
+                        label: i18n.t("FoodContentScreen.menuOptions.viewCreatorProfile"),
+                        onPress: handleViewCreator,
+                },
+                {
+                        icon: Calendar,
+                        label: i18n.t("FoodContentScreen.menuOptions.reservation"),
+                        onPress: () => console.log("Reservation"),
+                },
+        ];
 
 	const renderStars = (count: number, filled: number) => {
 		return (
@@ -97,9 +110,9 @@ export default function FoodContentScreen({ item }: FoodContentScreenProps) {
               <Text style={styles.reviewCount}>(127)</Text>
             </View> */}
 					</View>
-					<View style={styles.priceRatingContainer}>
-						<Text style={styles.price}>渋谷駅から徒歩13分</Text>
-					</View>
+                                        <View style={styles.priceRatingContainer}>
+                                                <Text style={styles.price}>{i18n.t("FoodContentScreen.info.walkFromShibuya")}</Text>
+                                        </View>
 				</View>
 				<View style={styles.headerRight}>
 					{/* <TouchableOpacity
@@ -174,12 +187,12 @@ export default function FoodContentScreen({ item }: FoodContentScreenProps) {
 							<Bookmark size={30} color={"transparent"} fill={isSaved ? "orange" : "white"} />
 						</TouchableOpacity>
 
-						<View style={styles.actionContainer}>
-							<TouchableOpacity style={styles.actionButton} onPress={() => {}}>
-								<Share size={28} color="#FFFFFF" />
-							</TouchableOpacity>
-							<Text style={styles.actionText}>Share</Text>
-						</View>
+                                                <View style={styles.actionContainer}>
+                                                        <TouchableOpacity style={styles.actionButton} onPress={() => {}}>
+                                                                <Share size={28} color="#FFFFFF" />
+                                                        </TouchableOpacity>
+                                                        <Text style={styles.actionText}>{i18n.t("FoodContentScreen.actions.share")}</Text>
+                                                </View>
 
 						<View style={styles.actionContainer}>
 							<TouchableOpacity style={styles.actionButton} onPress={() => {}}>

--- a/app-expo/components/ImageCardGrid.tsx
+++ b/app-expo/components/ImageCardGrid.tsx
@@ -1,15 +1,16 @@
 import React, { memo, ReactNode, useCallback, useMemo } from "react";
 import {
-	FlatList,
-	Image,
-	ListRenderItemInfo,
-	Pressable,
+        FlatList,
+        Image,
+        ListRenderItemInfo,
+        Pressable,
 	StyleProp,
 	StyleSheet,
 	useWindowDimensions,
 	ViewStyle,
 } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
+import i18n from "@/lib/i18n";
 
 /* -------------------------------------------------------------------------- */
 /*                                  型定義                                    */
@@ -78,11 +79,11 @@ function ImageCard<T extends ImageCardItem>({
 		<Pressable
 			style={[styles.card, { width: size, height, marginBottom: gap }, cardStyle]}
 			onPress={handlePress}
-			disabled={!onPress}
-			android_ripple={{ color: "rgba(0,0,0,0.06)" }}
-			accessibilityRole="button"
-			accessibilityLabel="Open item details">
-			<Image source={{ uri: item.imageUrl }} resizeMode="cover" style={StyleSheet.absoluteFillObject} />
+                        disabled={!onPress}
+                        android_ripple={{ color: "rgba(0,0,0,0.06)" }}
+                        accessibilityRole="button"
+                        accessibilityLabel={i18n.t("ImageCardGrid.openItemDetails")}>
+                        <Image source={{ uri: item.imageUrl }} resizeMode="cover" style={StyleSheet.absoluteFillObject} />
 			<LinearGradient
 				colors={["rgba(0,0,0,0)", "rgba(0,0,0,0.1)"]}
 				style={StyleSheet.absoluteFill}

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -31,7 +31,26 @@
 			"subtitle": "يرجى الانتظار..."
 		}
 	},
-	"Notifications": {
-		"title": "الإشعارات"
-	}
+        "Notifications": {
+                "title": "الإشعارات"
+        },
+        "FoodContentScreen": {
+                "numberSuffix": {
+                        "million": "M",
+                        "thousand": "K"
+                },
+                "menuOptions": {
+                        "viewCreatorProfile": "انتقل إلى ملف المُنشئ",
+                        "reservation": "حجز"
+                },
+                "actions": {
+                        "share": "مشاركة"
+                },
+                "info": {
+                        "walkFromShibuya": "على بُعد 13 دقيقة سيرًا من محطة شيبويا"
+                }
+        },
+        "ImageCardGrid": {
+                "openItemDetails": "فتح تفاصيل العنصر"
+        }
 }

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -31,7 +31,26 @@
 			"subtitle": "Please wait a moment..."
 		}
 	},
-	"Notifications": {
-		"title": "Notifications"
-	}
+        "Notifications": {
+                "title": "Notifications"
+        },
+        "FoodContentScreen": {
+                "numberSuffix": {
+                        "million": "M",
+                        "thousand": "K"
+                },
+                "menuOptions": {
+                        "viewCreatorProfile": "Go to creator profile",
+                        "reservation": "Reservation"
+                },
+                "actions": {
+                        "share": "Share"
+                },
+                "info": {
+                        "walkFromShibuya": "13 min walk from Shibuya Station"
+                }
+        },
+        "ImageCardGrid": {
+                "openItemDetails": "Open item details"
+        }
 }

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -31,7 +31,26 @@
 			"subtitle": "Por favor, espera..."
 		}
 	},
-	"Notifications": {
-		"title": "Notificaciones"
-	}
+        "Notifications": {
+                "title": "Notificaciones"
+        },
+        "FoodContentScreen": {
+                "numberSuffix": {
+                        "million": "M",
+                        "thousand": "K"
+                },
+                "menuOptions": {
+                        "viewCreatorProfile": "Ver perfil del creador",
+                        "reservation": "Reserva"
+                },
+                "actions": {
+                        "share": "Compartir"
+                },
+                "info": {
+                        "walkFromShibuya": "A 13 min a pie de la estación de Shibuya"
+                }
+        },
+        "ImageCardGrid": {
+                "openItemDetails": "Abrir detalles del elemento"
+        }
 }

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -31,7 +31,26 @@
 			"subtitle": "Veuillez patienter..."
 		}
 	},
-	"Notifications": {
-		"title": "Notifications"
-	}
+        "Notifications": {
+                "title": "Notifications"
+        },
+        "FoodContentScreen": {
+                "numberSuffix": {
+                        "million": "M",
+                        "thousand": "K"
+                },
+                "menuOptions": {
+                        "viewCreatorProfile": "Voir le profil du créateur",
+                        "reservation": "Réservation"
+                },
+                "actions": {
+                        "share": "Partager"
+                },
+                "info": {
+                        "walkFromShibuya": "À 13 min à pied de la gare de Shibuya"
+                }
+        },
+        "ImageCardGrid": {
+                "openItemDetails": "Ouvrir les détails de l'article"
+        }
 }

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -31,7 +31,26 @@
 			"subtitle": "कृपया प्रतीक्षा करें..."
 		}
 	},
-	"Notifications": {
-		"title": "सूचनाएँ"
-	}
+        "Notifications": {
+                "title": "सूचनाएँ"
+        },
+        "FoodContentScreen": {
+                "numberSuffix": {
+                        "million": "M",
+                        "thousand": "K"
+                },
+                "menuOptions": {
+                        "viewCreatorProfile": "निर्माता की प्रोफ़ाइल पर जाएँ",
+                        "reservation": "आरक्षण"
+                },
+                "actions": {
+                        "share": "साझा करें"
+                },
+                "info": {
+                        "walkFromShibuya": "शिबुया स्टेशन से 13 मिनट की पैदल दूरी"
+                }
+        },
+        "ImageCardGrid": {
+                "openItemDetails": "आइटम विवरण खोलें"
+        }
 }

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -31,7 +31,26 @@
 			"subtitle": "少々お待ちください..."
 		}
 	},
-	"Notifications": {
-		"title": "通知"
-	}
+        "Notifications": {
+                "title": "通知"
+        },
+        "FoodContentScreen": {
+                "numberSuffix": {
+                        "million": "M",
+                        "thousand": "K"
+                },
+                "menuOptions": {
+                        "viewCreatorProfile": "投稿者プロフィールへ",
+                        "reservation": "予約"
+                },
+                "actions": {
+                        "share": "シェア"
+                },
+                "info": {
+                        "walkFromShibuya": "渋谷駅から徒歩13分"
+                }
+        },
+        "ImageCardGrid": {
+                "openItemDetails": "詳細を表示"
+        }
 }

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -31,7 +31,26 @@
 			"subtitle": "잠시만 기다려 주세요..."
 		}
 	},
-	"Notifications": {
-		"title": "알림"
-	}
+        "Notifications": {
+                "title": "알림"
+        },
+        "FoodContentScreen": {
+                "numberSuffix": {
+                        "million": "M",
+                        "thousand": "K"
+                },
+                "menuOptions": {
+                        "viewCreatorProfile": "작성자 프로필로 이동",
+                        "reservation": "예약"
+                },
+                "actions": {
+                        "share": "공유하기"
+                },
+                "info": {
+                        "walkFromShibuya": "시부야역에서 도보 13분"
+                }
+        },
+        "ImageCardGrid": {
+                "openItemDetails": "항목 세부정보 열기"
+        }
 }

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -31,7 +31,26 @@
 			"subtitle": "请稍候..."
 		}
 	},
-	"Notifications": {
-		"title": "通知"
-	}
+        "Notifications": {
+                "title": "通知"
+        },
+        "FoodContentScreen": {
+                "numberSuffix": {
+                        "million": "M",
+                        "thousand": "K"
+                },
+                "menuOptions": {
+                        "viewCreatorProfile": "查看创作者资料",
+                        "reservation": "预订"
+                },
+                "actions": {
+                        "share": "分享"
+                },
+                "info": {
+                        "walkFromShibuya": "距离涩谷站步行13分钟"
+                }
+        },
+        "ImageCardGrid": {
+                "openItemDetails": "打开项目详情"
+        }
 }


### PR DESCRIPTION
## Summary
- replace hardcoded component strings with i18n lookups
- extend locale dictionaries for new component keys

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `pnpm typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6892422ff5e0832b838148dc40ff9e19