### PR TITLE
feat: use blur modal for hiding topics

### DIFF
--- a/app-expo/app/(tabs)/search/topics.tsx
+++ b/app-expo/app/(tabs)/search/topics.tsx
@@ -22,13 +22,16 @@ export default function TopicsScreen() {
 	const carouselRef = useRef<any>(null);
 	const setDishes = useSearchStore((state) => state.setDishes);
 
-	const { topics, isLoading, error, searchTopics, hideTopic } = useTopicSearch();
-	const { showSnackbar } = useSnackbar();
-	const { showHideModal, setShowHideModal, hideReason, setHideReason, handleHideCard, confirmHideCard } = useHideTopic(
-		topics,
-		hideTopic,
-		showSnackbar,
-	);
+        const { topics, isLoading, error, searchTopics, hideTopic } = useTopicSearch();
+        const { showSnackbar } = useSnackbar();
+        const {
+                BlurModal: HideTopicBlurModal,
+                close: closeHideModal,
+                hideReason,
+                setHideReason,
+                handleHideCard,
+                confirmHideCard,
+        } = useHideTopic(topics, hideTopic, showSnackbar);
 
 	useEffect(() => {
 		if (searchParams) {
@@ -129,16 +132,17 @@ export default function TopicsScreen() {
 				</View>
 			)}
 
-			{/* Hide Card Modal */}
-			<HideTopicModal
-				visible={showHideModal}
-				onRequestClose={() => setShowHideModal(false)}
-				hideReason={hideReason}
-				setHideReason={setHideReason}
-				confirmHideCard={confirmHideCard}
-			/>
-		</LinearGradient>
-	);
+                        {/* Hide Card Modal */}
+                        <HideTopicBlurModal animationType="fade" contentContainerStyle={styles.modalOverlay}>
+                                <HideTopicModal
+                                        onClose={closeHideModal}
+                                        hideReason={hideReason}
+                                        setHideReason={setHideReason}
+                                        confirmHideCard={confirmHideCard}
+                                />
+                        </HideTopicBlurModal>
+                </LinearGradient>
+        );
 }
 
 const styles = StyleSheet.create({
@@ -241,12 +245,17 @@ const styles = StyleSheet.create({
 		width: "100%",
 		maxWidth: 320,
 	},
-	emptyText: {
-		fontSize: 18,
-		color: "#6B7280",
-		textAlign: "center",
-		marginBottom: 24,
-		lineHeight: 28,
-		fontWeight: "500",
-	},
+        emptyText: {
+                fontSize: 18,
+                color: "#6B7280",
+                textAlign: "center",
+                marginBottom: 24,
+                lineHeight: 28,
+                fontWeight: "500",
+        },
+        modalOverlay: {
+                flex: 1,
+                justifyContent: "center",
+                alignItems: "center",
+        },
 });

--- a/app-expo/features/topics/components/HideTopicModal.tsx
+++ b/app-expo/features/topics/components/HideTopicModal.tsx
@@ -1,67 +1,56 @@
 import React from "react";
-import { Modal, View, Text, StyleSheet, TouchableOpacity, TextInput } from "react-native";
+import { View, Text, StyleSheet, TouchableOpacity, TextInput } from "react-native";
 import { X } from "lucide-react-native";
 import { width } from "@/features/topics/constants";
 
 interface Props {
-	visible: boolean;
-	onRequestClose: () => void;
-	hideReason: string;
-	setHideReason: (text: string) => void;
-	confirmHideCard: () => void;
+        onClose: () => void;
+        hideReason: string;
+        setHideReason: (text: string) => void;
+        confirmHideCard: () => void;
 }
 
-// Modal displayed when a user chooses to hide a topic card
-export const HideTopicModal = ({ visible, onRequestClose, hideReason, setHideReason, confirmHideCard }: Props) => (
-	<Modal visible={visible} transparent={true} animationType="fade" onRequestClose={onRequestClose}>
-		<View style={styles.modalOverlay}>
-			<View style={styles.modalContainer}>
-				<View style={styles.modalHeader}>
-					<Text style={styles.modalTitle}>非表示にする</Text>
-					<TouchableOpacity onPress={onRequestClose}>
-						<X size={24} color="#49454F" />
-					</TouchableOpacity>
-				</View>
+// Content for the hide topic modal
+export const HideTopicModal = ({ onClose, hideReason, setHideReason, confirmHideCard }: Props) => (
+        <View style={styles.modalContainer}>
+                <View style={styles.modalHeader}>
+                        <Text style={styles.modalTitle}>非表示にする</Text>
+                        <TouchableOpacity onPress={onClose}>
+                                <X size={24} color="#49454F" />
+                        </TouchableOpacity>
+                </View>
 
-				<Text style={styles.modalDescription}>非表示にする理由を教えてください（任意）</Text>
+                <Text style={styles.modalDescription}>非表示にする理由を教えてください（任意）</Text>
 
-				<TextInput
-					style={styles.reasonInput}
-					placeholder="理由を入力してください..."
-					value={hideReason}
-					onChangeText={setHideReason}
-					multiline
-					numberOfLines={3}
-					textAlignVertical="top"
-					placeholderTextColor="#79747E"
-				/>
+                <TextInput
+                        style={styles.reasonInput}
+                        placeholder="理由を入力してください..."
+                        value={hideReason}
+                        onChangeText={setHideReason}
+                        multiline
+                        numberOfLines={3}
+                        textAlignVertical="top"
+                        placeholderTextColor="#79747E"
+                />
 
-				<View style={styles.modalActions}>
-					<TouchableOpacity style={styles.cancelButton} onPress={onRequestClose}>
-						<Text style={styles.cancelButtonText}>キャンセル</Text>
-					</TouchableOpacity>
-					<TouchableOpacity style={styles.confirmButton} onPress={confirmHideCard}>
-						<Text style={styles.confirmButtonText}>非表示にする</Text>
-					</TouchableOpacity>
-				</View>
-			</View>
-		</View>
-	</Modal>
+                <View style={styles.modalActions}>
+                        <TouchableOpacity style={styles.cancelButton} onPress={onClose}>
+                                <Text style={styles.cancelButtonText}>キャンセル</Text>
+                        </TouchableOpacity>
+                        <TouchableOpacity style={styles.confirmButton} onPress={confirmHideCard}>
+                                <Text style={styles.confirmButtonText}>非表示にする</Text>
+                        </TouchableOpacity>
+                </View>
+        </View>
 );
 
 const styles = StyleSheet.create({
-	modalOverlay: {
-		flex: 1,
-		backgroundColor: "rgba(0, 0, 0, 0.6)",
-		justifyContent: "center",
-		alignItems: "center",
-	},
-	modalContainer: {
-		backgroundColor: "#FFFFFF",
-		borderRadius: 24,
-		padding: 24,
-		width: width - 48,
-		maxWidth: 400,
+        modalContainer: {
+                backgroundColor: "#FFFFFF",
+                borderRadius: 24,
+                padding: 24,
+                width: width - 48,
+                maxWidth: 400,
 		shadowColor: "#000",
 		shadowOffset: { width: 0, height: 0 },
 		shadowOpacity: 0.3,

--- a/app-expo/features/topics/hooks/useHideTopic.ts
+++ b/app-expo/features/topics/hooks/useHideTopic.ts
@@ -1,40 +1,45 @@
 import { useState } from "react";
 import { Topic } from "@/types/search";
+import { useBlurModal } from "@/hooks/useBlurModal";
 
 // Manage hide topic modal state and actions
 export const useHideTopic = (
-	topics: Topic[],
-	hideTopic: (id: string, reason: string) => void,
-	showSnackbar: (message: string) => void,
+        topics: Topic[],
+        hideTopic: (id: string, reason: string) => void,
+        showSnackbar: (message: string) => void,
 ) => {
-	const [showHideModal, setShowHideModal] = useState(false);
-	const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
-	const [hideReason, setHideReason] = useState("");
+        const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
+        const [hideReason, setHideReason] = useState("");
+        const { BlurModal, open, close } = useBlurModal({
+                intensity: 100,
+                onClose: () => {
+                        setHideReason("");
+                        setSelectedCardId(null);
+                },
+        });
 
-	// Open modal for a specific card
-	const handleHideCard = (cardId: string) => {
-		setSelectedCardId(cardId);
-		setShowHideModal(true);
-	};
+        // Open modal for a specific card
+        const handleHideCard = (cardId: string) => {
+                setSelectedCardId(cardId);
+                open();
+        };
 
-	// Confirm hiding the selected card
-	const confirmHideCard = () => {
-		const selectedTopic = topics.find((topic) => topic.id === selectedCardId);
-		if (selectedCardId && selectedTopic) {
-			hideTopic(selectedCardId, hideReason);
-			setShowHideModal(false);
-			setHideReason("");
-			setSelectedCardId(null);
-			showSnackbar(`${selectedTopic?.topicTitle}を非表示にしました`);
-		}
-	};
+        // Confirm hiding the selected card
+        const confirmHideCard = () => {
+                const selectedTopic = topics.find((topic) => topic.id === selectedCardId);
+                if (selectedCardId && selectedTopic) {
+                        hideTopic(selectedCardId, hideReason);
+                        showSnackbar(`${selectedTopic?.topicTitle}を非表示にしました`);
+                        close();
+                }
+        };
 
-	return {
-		showHideModal,
-		setShowHideModal,
-		hideReason,
-		setHideReason,
-		handleHideCard,
-		confirmHideCard,
-	};
+        return {
+                BlurModal,
+                close,
+                hideReason,
+                setHideReason,
+                handleHideCard,
+                confirmHideCard,
+        };
 };


### PR DESCRIPTION
## Summary
- swap hide-topic modal to custom BlurModal
- adapt hook and modal content for blur-based UI

## Testing
- `pnpm --filter app-expo lint` (fails: ESLint couldn't find an eslint.config.js)
- `pnpm --filter app-expo typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6892404fd140832bab3ffcb454b528f8