### PR TITLE
feat: i18n for tabs and errors

### DIFF
--- a/app-expo/app/(tabs)/_layout.tsx
+++ b/app-expo/app/(tabs)/_layout.tsx
@@ -1,5 +1,6 @@
 import { Tabs } from "expo-router";
 import { House as Home, MapPinned, Bell, User, Code, Search } from "lucide-react-native";
+import i18n from "@/lib/i18n";
 
 const ICON_SIZE = 21; // ← 24 がデフォルト。ここを好きな値に
 
@@ -28,7 +29,7 @@ export default function TabLayout() {
 			<Tabs.Screen
 				name="(home)"
 				options={{
-					title: "ホーム",
+					title: i18n.t("Tabs.home"),
 					href: null,
 					tabBarIcon: ({ size, color }) => <Home size={ICON_SIZE} color={color} />,
 				}}
@@ -36,28 +37,28 @@ export default function TabLayout() {
 			<Tabs.Screen
 				name="search"
 				options={{
-					title: "検索",
+					title: i18n.t("Tabs.search"),
 					tabBarIcon: ({ size, color }) => <Search size={ICON_SIZE} color={color} />,
 				}}
 			/>
 			<Tabs.Screen
 				name="map"
 				options={{
-					title: "マップ",
+					title: i18n.t("Tabs.map"),
 					tabBarIcon: ({ size, color }) => <MapPinned size={ICON_SIZE} color={color} />,
 				}}
 			/>
 			<Tabs.Screen
 				name="notifications"
 				options={{
-					title: "通知",
+					title: i18n.t("Tabs.notifications"),
 					tabBarIcon: ({ size, color }) => <Bell size={ICON_SIZE} color={color} />,
 				}}
 			/>
 			<Tabs.Screen
 				name="profile"
 				options={{
-					title: "プロフィール",
+					title: i18n.t("Tabs.profile"),
 					tabBarIcon: ({ size, color }) => <User size={ICON_SIZE} color={color} />,
 				}}
 			/>

--- a/app-expo/app/(tabs)/notifications.tsx
+++ b/app-expo/app/(tabs)/notifications.tsx
@@ -78,7 +78,7 @@ export default function NotificationsScreen() {
 						<Text style={styles.username}>{notification.user.username}</Text>
 						<Text style={styles.message}> {notification.message}</Text>
 					</Text>
-					<Text style={styles.timestamp}>{notification.timestamp} ago</Text>
+					<Text style={styles.timestamp}>{i18n.t("Notifications.timeAgo", { time: notification.timestamp })}</Text>
 				</View>
 
 				{/* Right: Post Thumbnail or More Options */}
@@ -104,7 +104,7 @@ export default function NotificationsScreen() {
 		<SafeAreaView style={styles.container}>
 			{/* Header */}
 			<View style={styles.header}>
-                                <Text style={styles.headerTitle}>{i18n.t("Notifications.title")}</Text>
+				<Text style={styles.headerTitle}>{i18n.t("Notifications.title")}</Text>
 				{unreadCount > 0 && (
 					<View style={styles.unreadBadge}>
 						<Text style={styles.unreadBadgeText}>{unreadCount}</Text>

--- a/app-expo/app/+not-found.tsx
+++ b/app-expo/app/+not-found.tsx
@@ -1,14 +1,15 @@
 import { Link, Stack } from "expo-router";
 import { StyleSheet, Text, View } from "react-native";
+import i18n from "@/lib/i18n";
 
 export default function NotFoundScreen() {
 	return (
 		<>
-			<Stack.Screen options={{ title: "Oops!" }} />
+			<Stack.Screen options={{ title: i18n.t("NotFound.title") }} />
 			<View style={styles.container}>
-				<Text style={styles.text}>This screen doesn't exist.</Text>
+				<Text style={styles.text}>{i18n.t("NotFound.message")}</Text>
 				<Link href="/" style={styles.link}>
-					<Text>Go to home screen!</Text>
+					<Text>{i18n.t("NotFound.goHome")}</Text>
 				</Link>
 			</View>
 		</>

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -31,26 +31,39 @@
 			"subtitle": "يرجى الانتظار..."
 		}
 	},
-        "Notifications": {
-                "title": "الإشعارات"
-        },
-        "FoodContentScreen": {
-                "numberSuffix": {
-                        "million": "M",
-                        "thousand": "K"
-                },
-                "menuOptions": {
-                        "viewCreatorProfile": "انتقل إلى ملف المُنشئ",
-                        "reservation": "حجز"
-                },
-                "actions": {
-                        "share": "مشاركة"
-                },
-                "info": {
-                        "walkFromShibuya": "على بُعد 13 دقيقة سيرًا من محطة شيبويا"
-                }
-        },
-        "ImageCardGrid": {
-                "openItemDetails": "فتح تفاصيل العنصر"
-        }
+	"Notifications": {
+		"title": "الإشعارات",
+		"timeAgo": "قبل {{time}}"
+	},
+	"FoodContentScreen": {
+		"numberSuffix": {
+			"million": "M",
+			"thousand": "K"
+		},
+		"menuOptions": {
+			"viewCreatorProfile": "انتقل إلى ملف المُنشئ",
+			"reservation": "حجز"
+		},
+		"actions": {
+			"share": "مشاركة"
+		},
+		"info": {
+			"walkFromShibuya": "على بُعد 13 دقيقة سيرًا من محطة شيبويا"
+		}
+	},
+	"ImageCardGrid": {
+		"openItemDetails": "فتح تفاصيل العنصر"
+	},
+	"Tabs": {
+		"home": "الصفحة الرئيسية",
+		"search": "البحث",
+		"map": "الخريطة",
+		"notifications": "الإشعارات",
+		"profile": "الملف الشخصي"
+	},
+	"NotFound": {
+		"title": "عذرًا!",
+		"message": "هذه الشاشة غير موجودة.",
+		"goHome": "العودة إلى الشاشة الرئيسية!"
+	}
 }

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -31,26 +31,39 @@
 			"subtitle": "Please wait a moment..."
 		}
 	},
-        "Notifications": {
-                "title": "Notifications"
-        },
-        "FoodContentScreen": {
-                "numberSuffix": {
-                        "million": "M",
-                        "thousand": "K"
-                },
-                "menuOptions": {
-                        "viewCreatorProfile": "Go to creator profile",
-                        "reservation": "Reservation"
-                },
-                "actions": {
-                        "share": "Share"
-                },
-                "info": {
-                        "walkFromShibuya": "13 min walk from Shibuya Station"
-                }
-        },
-        "ImageCardGrid": {
-                "openItemDetails": "Open item details"
-        }
+	"Notifications": {
+		"title": "Notifications",
+		"timeAgo": "{{time}} ago"
+	},
+	"FoodContentScreen": {
+		"numberSuffix": {
+			"million": "M",
+			"thousand": "K"
+		},
+		"menuOptions": {
+			"viewCreatorProfile": "Go to creator profile",
+			"reservation": "Reservation"
+		},
+		"actions": {
+			"share": "Share"
+		},
+		"info": {
+			"walkFromShibuya": "13 min walk from Shibuya Station"
+		}
+	},
+	"ImageCardGrid": {
+		"openItemDetails": "Open item details"
+	},
+	"Tabs": {
+		"home": "Home",
+		"search": "Search",
+		"map": "Map",
+		"notifications": "Notifications",
+		"profile": "Profile"
+	},
+	"NotFound": {
+		"title": "Oops!",
+		"message": "This screen doesn't exist.",
+		"goHome": "Go to home screen!"
+	}
 }

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -31,26 +31,39 @@
 			"subtitle": "Por favor, espera..."
 		}
 	},
-        "Notifications": {
-                "title": "Notificaciones"
-        },
-        "FoodContentScreen": {
-                "numberSuffix": {
-                        "million": "M",
-                        "thousand": "K"
-                },
-                "menuOptions": {
-                        "viewCreatorProfile": "Ver perfil del creador",
-                        "reservation": "Reserva"
-                },
-                "actions": {
-                        "share": "Compartir"
-                },
-                "info": {
-                        "walkFromShibuya": "A 13 min a pie de la estación de Shibuya"
-                }
-        },
-        "ImageCardGrid": {
-                "openItemDetails": "Abrir detalles del elemento"
-        }
+	"Notifications": {
+		"title": "Notificaciones",
+		"timeAgo": "hace {{time}}"
+	},
+	"FoodContentScreen": {
+		"numberSuffix": {
+			"million": "M",
+			"thousand": "K"
+		},
+		"menuOptions": {
+			"viewCreatorProfile": "Ver perfil del creador",
+			"reservation": "Reserva"
+		},
+		"actions": {
+			"share": "Compartir"
+		},
+		"info": {
+			"walkFromShibuya": "A 13 min a pie de la estación de Shibuya"
+		}
+	},
+	"ImageCardGrid": {
+		"openItemDetails": "Abrir detalles del elemento"
+	},
+	"Tabs": {
+		"home": "Inicio",
+		"search": "Buscar",
+		"map": "Mapa",
+		"notifications": "Notificaciones",
+		"profile": "Perfil"
+	},
+	"NotFound": {
+		"title": "¡Vaya!",
+		"message": "Esta pantalla no existe.",
+		"goHome": "¡Ir a la pantalla de inicio!"
+	}
 }

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -31,26 +31,39 @@
 			"subtitle": "Veuillez patienter..."
 		}
 	},
-        "Notifications": {
-                "title": "Notifications"
-        },
-        "FoodContentScreen": {
-                "numberSuffix": {
-                        "million": "M",
-                        "thousand": "K"
-                },
-                "menuOptions": {
-                        "viewCreatorProfile": "Voir le profil du créateur",
-                        "reservation": "Réservation"
-                },
-                "actions": {
-                        "share": "Partager"
-                },
-                "info": {
-                        "walkFromShibuya": "À 13 min à pied de la gare de Shibuya"
-                }
-        },
-        "ImageCardGrid": {
-                "openItemDetails": "Ouvrir les détails de l'article"
-        }
+	"Notifications": {
+		"title": "Notifications",
+		"timeAgo": "il y a {{time}}"
+	},
+	"FoodContentScreen": {
+		"numberSuffix": {
+			"million": "M",
+			"thousand": "K"
+		},
+		"menuOptions": {
+			"viewCreatorProfile": "Voir le profil du créateur",
+			"reservation": "Réservation"
+		},
+		"actions": {
+			"share": "Partager"
+		},
+		"info": {
+			"walkFromShibuya": "À 13 min à pied de la gare de Shibuya"
+		}
+	},
+	"ImageCardGrid": {
+		"openItemDetails": "Ouvrir les détails de l'article"
+	},
+	"Tabs": {
+		"home": "Accueil",
+		"search": "Recherche",
+		"map": "Carte",
+		"notifications": "Notifications",
+		"profile": "Profil"
+	},
+	"NotFound": {
+		"title": "Oups !",
+		"message": "Cet écran n'existe pas.",
+		"goHome": "Retour à l'accueil !"
+	}
 }

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -31,26 +31,39 @@
 			"subtitle": "कृपया प्रतीक्षा करें..."
 		}
 	},
-        "Notifications": {
-                "title": "सूचनाएँ"
-        },
-        "FoodContentScreen": {
-                "numberSuffix": {
-                        "million": "M",
-                        "thousand": "K"
-                },
-                "menuOptions": {
-                        "viewCreatorProfile": "निर्माता की प्रोफ़ाइल पर जाएँ",
-                        "reservation": "आरक्षण"
-                },
-                "actions": {
-                        "share": "साझा करें"
-                },
-                "info": {
-                        "walkFromShibuya": "शिबुया स्टेशन से 13 मिनट की पैदल दूरी"
-                }
-        },
-        "ImageCardGrid": {
-                "openItemDetails": "आइटम विवरण खोलें"
-        }
+	"Notifications": {
+		"title": "सूचनाएँ",
+		"timeAgo": "{{time}} पहले"
+	},
+	"FoodContentScreen": {
+		"numberSuffix": {
+			"million": "M",
+			"thousand": "K"
+		},
+		"menuOptions": {
+			"viewCreatorProfile": "निर्माता की प्रोफ़ाइल पर जाएँ",
+			"reservation": "आरक्षण"
+		},
+		"actions": {
+			"share": "साझा करें"
+		},
+		"info": {
+			"walkFromShibuya": "शिबुया स्टेशन से 13 मिनट की पैदल दूरी"
+		}
+	},
+	"ImageCardGrid": {
+		"openItemDetails": "आइटम विवरण खोलें"
+	},
+	"Tabs": {
+		"home": "होम",
+		"search": "खोज",
+		"map": "मानचित्र",
+		"notifications": "सूचनाएँ",
+		"profile": "प्रोफ़ाइल"
+	},
+	"NotFound": {
+		"title": "ओह!",
+		"message": "यह स्क्रीन मौजूद नहीं है।",
+		"goHome": "मुख्य स्क्रीन पर जाएँ!"
+	}
 }

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -31,26 +31,39 @@
 			"subtitle": "少々お待ちください..."
 		}
 	},
-        "Notifications": {
-                "title": "通知"
-        },
-        "FoodContentScreen": {
-                "numberSuffix": {
-                        "million": "M",
-                        "thousand": "K"
-                },
-                "menuOptions": {
-                        "viewCreatorProfile": "投稿者プロフィールへ",
-                        "reservation": "予約"
-                },
-                "actions": {
-                        "share": "シェア"
-                },
-                "info": {
-                        "walkFromShibuya": "渋谷駅から徒歩13分"
-                }
-        },
-        "ImageCardGrid": {
-                "openItemDetails": "詳細を表示"
-        }
+	"Notifications": {
+		"title": "通知",
+		"timeAgo": "{{time}}前"
+	},
+	"FoodContentScreen": {
+		"numberSuffix": {
+			"million": "M",
+			"thousand": "K"
+		},
+		"menuOptions": {
+			"viewCreatorProfile": "投稿者プロフィールへ",
+			"reservation": "予約"
+		},
+		"actions": {
+			"share": "シェア"
+		},
+		"info": {
+			"walkFromShibuya": "渋谷駅から徒歩13分"
+		}
+	},
+	"ImageCardGrid": {
+		"openItemDetails": "詳細を表示"
+	},
+	"Tabs": {
+		"home": "ホーム",
+		"search": "検索",
+		"map": "マップ",
+		"notifications": "通知",
+		"profile": "プロフィール"
+	},
+	"NotFound": {
+		"title": "おっと！",
+		"message": "この画面は存在しません。",
+		"goHome": "ホーム画面へ戻る"
+	}
 }

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -31,26 +31,39 @@
 			"subtitle": "잠시만 기다려 주세요..."
 		}
 	},
-        "Notifications": {
-                "title": "알림"
-        },
-        "FoodContentScreen": {
-                "numberSuffix": {
-                        "million": "M",
-                        "thousand": "K"
-                },
-                "menuOptions": {
-                        "viewCreatorProfile": "작성자 프로필로 이동",
-                        "reservation": "예약"
-                },
-                "actions": {
-                        "share": "공유하기"
-                },
-                "info": {
-                        "walkFromShibuya": "시부야역에서 도보 13분"
-                }
-        },
-        "ImageCardGrid": {
-                "openItemDetails": "항목 세부정보 열기"
-        }
+	"Notifications": {
+		"title": "알림",
+		"timeAgo": "{{time}} 전"
+	},
+	"FoodContentScreen": {
+		"numberSuffix": {
+			"million": "M",
+			"thousand": "K"
+		},
+		"menuOptions": {
+			"viewCreatorProfile": "작성자 프로필로 이동",
+			"reservation": "예약"
+		},
+		"actions": {
+			"share": "공유하기"
+		},
+		"info": {
+			"walkFromShibuya": "시부야역에서 도보 13분"
+		}
+	},
+	"ImageCardGrid": {
+		"openItemDetails": "항목 세부정보 열기"
+	},
+	"Tabs": {
+		"home": "홈",
+		"search": "검색",
+		"map": "지도",
+		"notifications": "알림",
+		"profile": "프로필"
+	},
+	"NotFound": {
+		"title": "이런!",
+		"message": "이 화면은 존재하지 않습니다.",
+		"goHome": "홈 화면으로 이동!"
+	}
 }

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -31,26 +31,39 @@
 			"subtitle": "请稍候..."
 		}
 	},
-        "Notifications": {
-                "title": "通知"
-        },
-        "FoodContentScreen": {
-                "numberSuffix": {
-                        "million": "M",
-                        "thousand": "K"
-                },
-                "menuOptions": {
-                        "viewCreatorProfile": "查看创作者资料",
-                        "reservation": "预订"
-                },
-                "actions": {
-                        "share": "分享"
-                },
-                "info": {
-                        "walkFromShibuya": "距离涩谷站步行13分钟"
-                }
-        },
-        "ImageCardGrid": {
-                "openItemDetails": "打开项目详情"
-        }
+	"Notifications": {
+		"title": "通知",
+		"timeAgo": "{{time}}前"
+	},
+	"FoodContentScreen": {
+		"numberSuffix": {
+			"million": "M",
+			"thousand": "K"
+		},
+		"menuOptions": {
+			"viewCreatorProfile": "查看创作者资料",
+			"reservation": "预订"
+		},
+		"actions": {
+			"share": "分享"
+		},
+		"info": {
+			"walkFromShibuya": "距离涩谷站步行13分钟"
+		}
+	},
+	"ImageCardGrid": {
+		"openItemDetails": "打开项目详情"
+	},
+	"Tabs": {
+		"home": "首页",
+		"search": "搜索",
+		"map": "地图",
+		"notifications": "通知",
+		"profile": "个人资料"
+	},
+	"NotFound": {
+		"title": "哎呀！",
+		"message": "此屏幕不存在。",
+		"goHome": "返回首页！"
+	}
 }


### PR DESCRIPTION
## Summary
- localize tab titles and error screen
- add notification timestamp helper

## Testing
- `pnpm --filter app-expo lint` *(fails: ESLint couldn't find an eslint.config file)*
- `pnpm --filter app-expo typecheck`
- `pnpm --filter app-expo test -- --watchAll=false` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68924d020f24832bb45fa64bb55e8006