### PR TITLE
feat: use AppLoggerService for logging

### DIFF
--- a/api/src/core/prompt/prompt.service.ts
+++ b/api/src/core/prompt/prompt.service.ts
@@ -3,68 +3,83 @@
 // Prompt service for managing prompt families, variants, and usage logging
 //
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { StaticMasterService } from '../utils/static-master.service';
 import { pickByWeight } from '../utils/weight.utils';
 import { PrismaService } from '../../prisma/prisma.service';
 import { Prisma } from '../../../../shared/prisma';
 import { CLS_KEY_REQUEST_ID } from '../cls/cls.constants';
 import { ClsService } from 'nestjs-cls';
+import { AppLoggerService } from '../logger/logger.service';
 
 @Injectable()
 export class PromptService {
-  private readonly logger = new Logger(PromptService.name);
-
   constructor(
     private readonly staticMasterService: StaticMasterService,
     private readonly prisma: PrismaService,
     private readonly cls: ClsService,
-  ) { }
+    private readonly logger: AppLoggerService,
+  ) {}
 
   /**
    * プロンプトファミリーとバリアントを取得し、重み付け選択を行う
    */
   async getPromptForPurpose(purpose: string) {
-    this.logger.debug(`Getting prompt for purpose: ${purpose}`);
+    this.logger.debug('GetPromptForPurpose', 'getPromptForPurpose', {
+      purpose,
+    });
 
     try {
       // Static Masterからプロンプトファミリーを取得
-      const promptFamilies = await this.staticMasterService.getStaticMaster('prompt_families');
+      const promptFamilies =
+        await this.staticMasterService.getStaticMaster('prompt_families');
       const eligibleFamilies = promptFamilies
         .filter((x) => x.purpose === purpose)
         .filter((x) => x.weight > 0);
 
       if (eligibleFamilies.length === 0) {
-        this.logger.warn(`No eligible prompt families found for purpose: ${purpose}`);
+        this.logger.warn('NoEligiblePromptFamilies', 'getPromptForPurpose', {
+          purpose,
+        });
         return null;
       }
 
       // 重み付け選択でファミリーを選択
       const selectedFamily = pickByWeight(eligibleFamilies);
       if (!selectedFamily) {
-        this.logger.warn(`Failed to select prompt family for purpose: ${purpose}`);
+        this.logger.warn('PromptFamilySelectionFailed', 'getPromptForPurpose', {
+          purpose,
+        });
         return null;
       }
 
       // バリアントを取得（最新バージョンを選択）
-      const promptVariants = await this.staticMasterService.getStaticMaster('prompt_variants');
+      const promptVariants =
+        await this.staticMasterService.getStaticMaster('prompt_variants');
       const selectedVariant = promptVariants
         .filter((x) => x.family_id === selectedFamily.id)
         .sort((a, b) => b.variant_number - a.variant_number)[0];
 
       if (!selectedVariant) {
-        this.logger.warn(`No prompt variant found for family: ${selectedFamily.id}`);
+        this.logger.warn('NoPromptVariantFound', 'getPromptForPurpose', {
+          familyId: selectedFamily.id,
+        });
         return null;
       }
 
-      this.logger.debug(`Selected prompt family ${selectedFamily.id} variant ${selectedVariant.variant_number}`);
+      this.logger.debug('PromptVariantSelected', 'getPromptForPurpose', {
+        familyId: selectedFamily.id,
+        variantNumber: selectedVariant.variant_number,
+      });
       return {
         family: selectedFamily,
         variant: selectedVariant,
       };
-
     } catch (error) {
-      this.logger.error('Failed to get prompt for purpose', error);
+      this.logger.error('GetPromptForPurposeError', 'getPromptForPurpose', {
+        error_message: error instanceof Error ? error.message : String(error),
+        purpose,
+      });
       return null;
     }
   }
@@ -72,8 +87,13 @@ export class PromptService {
   /**
    * プロンプト使用履歴を記録
    */
-  async createPromptUsage(params: Omit<Prisma.prompt_usagesCreateInput, 'id' | 'created_at' | 'created_request_id'>): Promise<void> {
-    this.logger.debug('Creating prompt usage record', {
+  async createPromptUsage(
+    params: Omit<
+      Prisma.prompt_usagesCreateInput,
+      'id' | 'created_at' | 'created_request_id'
+    >,
+  ): Promise<void> {
+    this.logger.debug('CreatePromptUsage', 'createPromptUsage', {
       family_id: params.family_id,
       variant_id: params.variant_id,
       target_type: params.target_type,
@@ -99,10 +119,11 @@ export class PromptService {
         },
       });
 
-      this.logger.debug('Prompt usage record created successfully');
-
+      this.logger.debug('PromptUsageCreated', 'createPromptUsage', {});
     } catch (error) {
-      this.logger.error('Failed to create prompt usage record', error);
+      this.logger.error('CreatePromptUsageError', 'createPromptUsage', {
+        error_message: error instanceof Error ? error.message : String(error),
+      });
       // Don't throw here - logging failure shouldn't break the main flow
     }
   }

--- a/api/src/core/utils/static-master.service.ts
+++ b/api/src/core/utils/static-master.service.ts
@@ -1,17 +1,16 @@
 // api/src/core/utils/static-master.service.ts
 //
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Database } from '../../../../shared/supabase/database.types';
 import { TableRow } from '../../../../shared/utils/devDB.types';
 import { loadStaticMaster } from '../../../../shared/utils/loadStaticMaster';
 import { env } from '../config/env';
+import { AppLoggerService } from '../logger/logger.service';
 
 @Injectable()
 export class StaticMasterService {
-  private readonly logger = new Logger(StaticMasterService.name);
-
-  constructor() { }
+  constructor(private readonly logger: AppLoggerService) {}
 
   /** ───────── キャッシュ領域 ───────── */
   private cache: Partial<
@@ -24,7 +23,6 @@ export class StaticMasterService {
 
   private readonly CACHE_TTL_MS = 5 * 60 * 1_000; // 5 min
 
-
   /**
    * 🗂️ 静的マスタデータを取得するユーティリティ関数。
    *
@@ -34,7 +32,7 @@ export class StaticMasterService {
    * @param tableName - 対象となるマスタテーブル名（Supabase dev スキーマ）
    * @returns 該当マスタのレコード配列
    */
-  async getStaticMaster<T extends keyof Database["dev"]["Tables"]>(
+  async getStaticMaster<T extends keyof Database['dev']['Tables']>(
     tableName: T,
   ): Promise<TableRow<T>[]> {
     const now = Date.now();
@@ -42,7 +40,7 @@ export class StaticMasterService {
     const expired = now - last > this.CACHE_TTL_MS;
 
     if (!this.cache[tableName] || expired) {
-      this.logger.debug(`Cache miss → loading ${tableName} master`);
+      this.logger.debug('CacheMiss', 'getStaticMaster', { tableName });
       this.cache[tableName] = await loadStaticMaster(
         env.GCS_BUCKET_NAME,
         env.GCS_STATIC_MASTER_DIR_PATH,
@@ -52,5 +50,5 @@ export class StaticMasterService {
     }
 
     return this.cache[tableName] as TableRow<T>[];
-  };
+  }
 }

--- a/api/src/prisma/prisma.service.ts
+++ b/api/src/prisma/prisma.service.ts
@@ -1,11 +1,7 @@
-import {
-  Injectable,
-  OnModuleInit,
-  OnModuleDestroy,
-  Logger,
-} from '@nestjs/common';
+import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
 import { PrismaClient, Prisma } from '../../../shared/prisma/client';
 import { MetricsMiddleware } from './middlewares/metrics.middleware';
+import { AppLoggerService } from '../core/logger/logger.service';
 
 /**
  * PrismaService
@@ -19,9 +15,7 @@ export class PrismaService
   extends PrismaClient
   implements OnModuleInit, OnModuleDestroy
 {
-  private readonly logger = new Logger(PrismaService.name);
-
-  constructor() {
+  constructor(private readonly logger: AppLoggerService) {
     // ★ 注意：ここで log レベルを細かく制御すると、開発時の読みやすさ向上
     super({
       log:
@@ -38,9 +32,9 @@ export class PrismaService
   // ----- Nest Lifecycle ---------------------------------------
 
   async onModuleInit() {
-    this.logger.log('Connecting to DB…');
+    this.logger.log('PrismaConnecting', 'onModuleInit', {});
     await this.$connect();
-    this.logger.log('Prisma connected.');
+    this.logger.log('PrismaConnected', 'onModuleInit', {});
 
     // （任意）マイグレーションを自動で当てたい場合
     // if (process.env.NODE_ENV !== 'production') {
@@ -49,7 +43,7 @@ export class PrismaService
   }
 
   async onModuleDestroy() {
-    this.logger.log('Disconnecting Prisma…');
+    this.logger.log('PrismaDisconnecting', 'onModuleDestroy', {});
     await this.$disconnect();
   }
 

--- a/api/src/v1/dish-categories/dish-categories.repository.ts
+++ b/api/src/v1/dish-categories/dish-categories.repository.ts
@@ -3,21 +3,28 @@
 // Repository for dish categories data access
 //
 
-import { Injectable, Logger } from '@nestjs/common';
-import { Prisma } from '../../../../shared/prisma/client';
+import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
+import { AppLoggerService } from '../../core/logger/logger.service';
 
 @Injectable()
 export class DishCategoriesRepository {
-  private readonly logger = new Logger(DishCategoriesRepository.name);
-
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly logger: AppLoggerService,
+  ) {}
 
   /**
    * カテゴリ名リストから料理カテゴリを検索
    */
   async findDishCategoriesByNames(categoryNames: string[]) {
-    this.logger.debug(`Finding dish categories for: ${categoryNames.join(', ')}`);
+    this.logger.debug(
+      'FindDishCategoriesByNames',
+      'findDishCategoriesByNames',
+      {
+        categoryNames,
+      },
+    );
 
     const result = await this.prisma.dish_categories.findMany({
       where: {
@@ -40,7 +47,9 @@ export class DishCategoriesRepository {
       },
     });
 
-    this.logger.debug(`Found ${result.length} dish categories`);
+    this.logger.debug('DishCategoriesFound', 'findDishCategoriesByNames', {
+      count: result.length,
+    });
     return result;
   }
 }

--- a/api/src/v1/dish-categories/dish-categories.service.ts
+++ b/api/src/v1/dish-categories/dish-categories.service.ts
@@ -3,21 +3,21 @@
 // Service for dish categories business logic
 //
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { QueryDishCategoryRecommendationsDto } from '@shared/v1/dto';
 import { QueryDishCategoryRecommendationsResponse } from '@shared/v1/res';
 
 import { DishCategoriesRepository } from './dish-categories.repository';
 import { ClaudeService } from '../../core/claude/claude.service';
+import { AppLoggerService } from '../../core/logger/logger.service';
 
 @Injectable()
 export class DishCategoriesService {
-  private readonly logger = new Logger(DishCategoriesService.name);
-
   constructor(
     private readonly repo: DishCategoriesRepository,
     private readonly claudeService: ClaudeService,
-  ) { }
+    private readonly logger: AppLoggerService,
+  ) {}
 
   /**
    * 料理カテゴリ提案を生成
@@ -25,45 +25,50 @@ export class DishCategoriesService {
   async getRecommendations(
     dto: QueryDishCategoryRecommendationsDto,
   ): Promise<QueryDishCategoryRecommendationsResponse> {
-    this.logger.debug('Getting dish category recommendations', dto);
+    this.logger.debug('GetRecommendations', 'getRecommendations', dto);
 
     // Claude API で料理カテゴリ提案を生成
-    const claudeRecommendations = await this.claudeService.generateDishCategoryRecommendations({
-      location: dto.location,
-      timeSlot: dto.timeSlot,
-      scene: dto.scene,
-      mood: dto.mood,
-      restrictions: dto.restrictions,
-      distance: dto.distance,
-      budgetMin: dto.budgetMin,
-      budgetMax: dto.budgetMax,
-    });
+    const claudeRecommendations =
+      await this.claudeService.generateDishCategoryRecommendations({
+        location: dto.location,
+        timeSlot: dto.timeSlot,
+        scene: dto.scene,
+        mood: dto.mood,
+        restrictions: dto.restrictions,
+        distance: dto.distance,
+        budgetMin: dto.budgetMin,
+        budgetMax: dto.budgetMax,
+      });
 
     // カテゴリ名リストを抽出
-    const categoryNames = claudeRecommendations.map(rec => rec.category);
+    const categoryNames = claudeRecommendations.map((rec) => rec.category);
 
     // データベースから該当する料理カテゴリを検索
-    const dishCategories = await this.repo.findDishCategoriesByNames(categoryNames);
+    const dishCategories =
+      await this.repo.findDishCategoriesByNames(categoryNames);
 
     // Claude の提案とデータベースの結果をマッピング
-    const response: QueryDishCategoryRecommendationsResponse = claudeRecommendations.map(claudeRec => {
-      // このカテゴリ名にマッチするデータベースレコードを探す
-      const matchedCategory = dishCategories.find(dbCategory =>
-        dbCategory.dish_category_variants.some(variant =>
-          variant.surface_form === claudeRec.category
-        )
-      );
+    const response: QueryDishCategoryRecommendationsResponse =
+      claudeRecommendations.map((claudeRec) => {
+        // このカテゴリ名にマッチするデータベースレコードを探す
+        const matchedCategory = dishCategories.find((dbCategory) =>
+          dbCategory.dish_category_variants.some(
+            (variant) => variant.surface_form === claudeRec.category,
+          ),
+        );
 
-      return {
-        category: claudeRec.category,
-        topicTitle: claudeRec.topicTitle,
-        reason: claudeRec.reason,
-        categoryId: matchedCategory?.id || '',
-        imageUrl: matchedCategory?.image_url || '',
-      };
+        return {
+          category: claudeRec.category,
+          topicTitle: claudeRec.topicTitle,
+          reason: claudeRec.reason,
+          categoryId: matchedCategory?.id || '',
+          imageUrl: matchedCategory?.image_url || '',
+        };
+      });
+
+    this.logger.debug('RecommendationsReturned', 'getRecommendations', {
+      count: response.length,
     });
-
-    this.logger.debug(`Returning ${response.length} recommendations`);
     return response;
   }
 }

--- a/api/src/v1/dish-category-variants/dish-category-variants.repository.ts
+++ b/api/src/v1/dish-category-variants/dish-category-variants.repository.ts
@@ -3,21 +3,26 @@
 // Repository for dish category variants data access
 //
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Prisma } from '../../../../shared/prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
+import { AppLoggerService } from '../../core/logger/logger.service';
 
 @Injectable()
 export class DishCategoryVariantsRepository {
-  private readonly logger = new Logger(DishCategoryVariantsRepository.name);
-
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly logger: AppLoggerService,
+  ) {}
 
   /**
    * 料理カテゴリ表記揺れを検索
    */
   async findDishCategoryVariants(q: string, lang?: string) {
-    this.logger.debug(`Finding dish category variants for: ${q}, lang: ${lang}`);
+    this.logger.debug('FindDishCategoryVariants', 'findDishCategoryVariants', {
+      q,
+      lang,
+    });
 
     const result = await this.prisma.dish_categories.findMany({
       where: {
@@ -41,7 +46,9 @@ export class DishCategoryVariantsRepository {
       take: 20, // limit 20
     });
 
-    this.logger.debug(`Found ${result.length} dish category variants`);
+    this.logger.debug('DishCategoryVariantsFound', 'findDishCategoryVariants', {
+      count: result.length,
+    });
     return result;
   }
 
@@ -49,7 +56,13 @@ export class DishCategoryVariantsRepository {
    * surface_form で料理カテゴリ表記揺れを検索
    */
   async findDishCategoryVariantBySurfaceForm(surfaceForm: string) {
-    this.logger.debug(`Finding dish category variant by surface form: ${surfaceForm}`);
+    this.logger.debug(
+      'FindVariantBySurfaceForm',
+      'findDishCategoryVariantBySurfaceForm',
+      {
+        surfaceForm,
+      },
+    );
 
     const result = await this.prisma.dish_category_variants.findUnique({
       where: {
@@ -60,7 +73,9 @@ export class DishCategoryVariantsRepository {
       },
     });
 
-    this.logger.debug(`Found variant: ${result ? 'yes' : 'no'}`);
+    this.logger.debug('VariantFound', 'findDishCategoryVariantBySurfaceForm', {
+      found: !!result,
+    });
     return result;
   }
 
@@ -73,7 +88,15 @@ export class DishCategoryVariantsRepository {
     surfaceForm: string,
     source?: string,
   ) {
-    this.logger.debug(`Creating dish category variant: ${surfaceForm} -> ${dishCategoryId}`);
+    this.logger.debug(
+      'CreateDishCategoryVariant',
+      'createDishCategoryVariant',
+      {
+        dishCategoryId,
+        surfaceForm,
+        source,
+      },
+    );
 
     const result = await tx.dish_category_variants.create({
       data: {
@@ -83,7 +106,13 @@ export class DishCategoryVariantsRepository {
       },
     });
 
-    this.logger.debug(`Created variant: ${result.id}`);
+    this.logger.debug(
+      'DishCategoryVariantCreated',
+      'createDishCategoryVariant',
+      {
+        id: result.id,
+      },
+    );
     return result;
   }
 
@@ -91,7 +120,9 @@ export class DishCategoryVariantsRepository {
    * QID で料理カテゴリを検索
    */
   async findDishCategoryByQid(qid: string) {
-    this.logger.debug(`Finding dish category by QID: ${qid}`);
+    this.logger.debug('FindDishCategoryByQid', 'findDishCategoryByQid', {
+      qid,
+    });
 
     // まずIDとして直接検索
     let result = await this.prisma.dish_categories.findUnique({
@@ -112,7 +143,9 @@ export class DishCategoryVariantsRepository {
       result = categories.length > 0 ? categories[0] : null;
     }
 
-    this.logger.debug(`Found category by QID: ${result ? 'yes' : 'no'}`);
+    this.logger.debug('DishCategoryByQidFound', 'findDishCategoryByQid', {
+      found: !!result,
+    });
     return result;
   }
 
@@ -120,11 +153,13 @@ export class DishCategoryVariantsRepository {
    * 料理カテゴリ一覧を取得
    */
   async getDishCategories() {
-    this.logger.debug('Getting dish categories');
+    this.logger.debug('GetDishCategories', 'getDishCategories', {});
 
     const result = await this.prisma.dish_categories.findMany();
 
-    this.logger.debug(`Found ${result.length} dish categories`);
+    this.logger.debug('DishCategoriesFound', 'getDishCategories', {
+      count: result.length,
+    });
     return result;
   }
 }

--- a/api/src/v1/dish-category-variants/dish-category-variants.service.ts
+++ b/api/src/v1/dish-category-variants/dish-category-variants.service.ts
@@ -3,30 +3,28 @@
 // Service for dish category variants business logic
 //
 
-import { Injectable, Logger, InternalServerErrorException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { Prisma } from '../../../../shared/prisma/client';
 import {
   QueryDishCategoryVariantsDto,
   CreateDishCategoryVariantDto,
 } from '@shared/v1/dto';
-import {
-  QueryDishCategoryVariantsResponse,
-} from '@shared/v1/res';
+import { QueryDishCategoryVariantsResponse } from '@shared/v1/res';
 
 import { DishCategoryVariantsRepository } from './dish-category-variants.repository';
 import { ExternalApiService } from '../../core/external-api/external-api.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { PrismaDishCategories } from '../../../../shared/converters/convert_dish_categories';
+import { AppLoggerService } from '../../core/logger/logger.service';
 
 @Injectable()
 export class DishCategoryVariantsService {
-  private readonly logger = new Logger(DishCategoryVariantsService.name);
-
   constructor(
     private readonly repo: DishCategoryVariantsRepository,
     private readonly externalApiService: ExternalApiService,
     private readonly prisma: PrismaService,
-  ) { }
+    private readonly logger: AppLoggerService,
+  ) {}
 
   /**
    * 料理カテゴリ表記揺れを検索
@@ -34,9 +32,16 @@ export class DishCategoryVariantsService {
   async findDishCategoryVariants(
     dto: QueryDishCategoryVariantsDto,
   ): Promise<QueryDishCategoryVariantsResponse> {
-    this.logger.debug('Finding dish category variants', dto);
+    this.logger.debug(
+      'FindDishCategoryVariants',
+      'findDishCategoryVariants',
+      dto,
+    );
 
-    const dishCategories = await this.repo.findDishCategoryVariants(dto.q, dto.lang);
+    const dishCategories = await this.repo.findDishCategoryVariants(
+      dto.q,
+      dto.lang,
+    );
 
     // レスポンス形式に変換 - 最大20件まで
     const response: QueryDishCategoryVariantsResponse = [];
@@ -45,11 +50,13 @@ export class DishCategoryVariantsService {
       if (response.length >= 20) break;
 
       for (const variant of category.dish_category_variants) {
+        void variant;
         if (response.length >= 20) break;
 
         // category.labels[lang] を使用（フォールバックあり）
         const labels = category.labels as Record<string, string>;
-        const label = dto.lang && labels[dto.lang] ? labels[dto.lang] : category.label_en;
+        const label =
+          dto.lang && labels[dto.lang] ? labels[dto.lang] : category.label_en;
 
         response.push({
           dishCategoryId: category.id,
@@ -58,7 +65,13 @@ export class DishCategoryVariantsService {
       }
     }
 
-    this.logger.debug(`Returning ${response.length} variants`);
+    this.logger.debug(
+      'DishCategoryVariantsReturned',
+      'findDishCategoryVariants',
+      {
+        count: response.length,
+      },
+    );
     return response;
   }
 
@@ -68,62 +81,84 @@ export class DishCategoryVariantsService {
   async createDishCategoryVariant(
     dto: CreateDishCategoryVariantDto,
   ): Promise<PrismaDishCategories> {
-    this.logger.debug('Creating dish category variant', dto);
+    this.logger.debug(
+      'CreateDishCategoryVariant',
+      'createDishCategoryVariant',
+      dto,
+    );
 
     // まず直接検索
-    let foundVariant = await this.repo.findDishCategoryVariantBySurfaceForm(dto.name);
+    let foundVariant = await this.repo.findDishCategoryVariantBySurfaceForm(
+      dto.name,
+    );
 
     if (foundVariant) {
-      this.logger.debug('Direct match found');
+      this.logger.debug('DirectMatchFound', 'createDishCategoryVariant', {});
       return foundVariant.dish_categories;
     }
 
     // Wikidata で検索（CLS情報を渡す）
-    const wikidataResult = await this.externalApiService.searchWikidata(dto.name);
+    const wikidataResult = await this.externalApiService.searchWikidata(
+      dto.name,
+    );
     if (wikidataResult) {
       // Wikidata結果のQIDから対応するDish Categoryを探す
-      const categoryByQid = await this.repo.findDishCategoryByQid(wikidataResult.qid);
+      const categoryByQid = await this.repo.findDishCategoryByQid(
+        wikidataResult.qid,
+      );
       if (!categoryByQid) {
         throw new InternalServerErrorException(
           `No dish category found for Wikidata QID: ${wikidataResult.qid}`,
         );
       }
       // 新しい表記揺れを登録
-      await this.prisma.withTransaction(async (tx: Prisma.TransactionClient) => {
-        await this.repo.createDishCategoryVariant(
-          tx,
-          categoryByQid.id,
-          dto.name,
-          'wikidata_qid_match'
-        );
-      });
+      await this.prisma.withTransaction(
+        async (tx: Prisma.TransactionClient) => {
+          await this.repo.createDishCategoryVariant(
+            tx,
+            categoryByQid.id,
+            dto.name,
+            'wikidata_qid_match',
+          );
+        },
+      );
 
       return categoryByQid;
     }
 
     // Google Custom Search でスペルチェック（CLS情報を渡す）
-    const correctedSpelling = await this.externalApiService.getCorrectedSpelling(dto.name);
+    const correctedSpelling =
+      await this.externalApiService.getCorrectedSpelling(dto.name);
     if (correctedSpelling) {
-      foundVariant = await this.repo.findDishCategoryVariantBySurfaceForm(correctedSpelling);
+      foundVariant =
+        await this.repo.findDishCategoryVariantBySurfaceForm(correctedSpelling);
       if (foundVariant) {
-        this.logger.debug('Corrected spelling match found');
+        this.logger.debug(
+          'CorrectedSpellingMatchFound',
+          'createDishCategoryVariant',
+          {},
+        );
 
         // 新しい表記揺れを登録
-        await this.prisma.withTransaction(async (tx: Prisma.TransactionClient) => {
-          await this.repo.createDishCategoryVariant(
-            tx,
-            foundVariant!.dish_categories.id,
-            dto.name,
-            'google_spelling_correction'
-          );
-        });
+        await this.prisma.withTransaction(
+          async (tx: Prisma.TransactionClient) => {
+            await this.repo.createDishCategoryVariant(
+              tx,
+              foundVariant!.dish_categories.id,
+              dto.name,
+              'google_spelling_correction',
+            );
+          },
+        );
 
         return foundVariant.dish_categories;
       }
     }
 
     // ヒットなし
-    this.logger.warn(`No match found for: ${dto.name}`);
+    this.logger.warn('NoMatchFound', 'createDishCategoryVariant', {
+      name: dto.name,
+    });
     throw new InternalServerErrorException('No matching dish category found');
   }
 }


### PR DESCRIPTION
## Summary
- replace NestJS Logger with core AppLoggerService across services
- leverage structured logging in Prisma and feature modules

## Testing
- `pnpm -F api exec eslint "src/core/storage/storage.service.ts" "src/core/prompt/prompt.service.ts" "src/core/utils/static-master.service.ts" "src/core/claude/claude.service.ts" "src/core/notifier/notifier.service.ts" "src/v1/dish-categories/dish-categories.repository.ts" "src/v1/dish-categories/dish-categories.service.ts" "src/v1/dish-category-variants/dish-category-variants.repository.ts" "src/v1/dish-category-variants/dish-category-variants.service.ts" "src/v1/dish-media/dish-media.service.ts" "src/prisma/prisma.service.ts"`
- `pnpm -F api test` *(fails: Cannot find module '@shared/v1/dto')*


------
https://chatgpt.com/codex/tasks/task_e_6893b45cdfcc832bb908bef0effc4459