### PR TITLE
refactor: add i18n translations

### DIFF
--- a/app-expo/app/(tabs)/(home)/restaurant/[restaurantId].tsx
+++ b/app-expo/app/(tabs)/(home)/restaurant/[restaurantId].tsx
@@ -138,8 +138,20 @@ export default function RestaurantScreen() {
 	});
 	const scrollViewRef = useRef<ScrollView>(null);
 
-	const priceRanges = ["¥1,000以下", "¥1,000-3,000", "¥3,000-5,000", "¥5,000以上"];
-	const categories = ["和食", "イタリアン", "フレンチ", "中華", "アジア料理", "その他"];
+    const priceRanges = [
+        i18n.t("Restaurant.filter.priceRanges.under1000", { currency: i18n.t("Search.currencySuffix") }),
+        i18n.t("Restaurant.filter.priceRanges.range1000to3000", { currency: i18n.t("Search.currencySuffix") }),
+        i18n.t("Restaurant.filter.priceRanges.range3000to5000", { currency: i18n.t("Search.currencySuffix") }),
+        i18n.t("Restaurant.filter.priceRanges.over5000", { currency: i18n.t("Search.currencySuffix") }),
+    ];
+    const categories = [
+        i18n.t("Restaurant.filter.categories.japanese"),
+        i18n.t("Restaurant.filter.categories.italian"),
+        i18n.t("Restaurant.filter.categories.french"),
+        i18n.t("Restaurant.filter.categories.chinese"),
+        i18n.t("Restaurant.filter.categories.asian"),
+        i18n.t("Restaurant.filter.categories.other"),
+    ];
 
 	const formatLikeCount = (count: number): string => {
 		if (count >= 1000000) {
@@ -279,11 +291,11 @@ export default function RestaurantScreen() {
 				<View style={styles.actionButtons}>
 					<TouchableOpacity style={styles.actionButton} onPress={handleMakeReservation}>
 						<Calendar size={20} color="#007AFF" />
-						<Text style={styles.actionButtonText}>予約する</Text>
+                                                <Text style={styles.actionButtonText}>{i18n.t("Restaurant.buttons.reserve")}</Text>
 					</TouchableOpacity>
 					<TouchableOpacity style={styles.actionButton} onPress={handlePostReview}>
 						<Camera size={20} color="#007AFF" />
-						<Text style={styles.actionButtonText}>画像・動画投稿</Text>
+                                                <Text style={styles.actionButtonText}>{i18n.t("Restaurant.buttons.postMedia")}</Text>
 					</TouchableOpacity>
 				</View>
 
@@ -292,14 +304,16 @@ export default function RestaurantScreen() {
 					<TouchableOpacity
 						style={[styles.tab, selectedTab === "posts" && styles.activeTab]}
 						onPress={() => setSelectedTab("posts")}>
-						<Text style={[styles.tabText, selectedTab === "posts" && styles.activeTabText]}>
-							投稿 {foodPosts.length}
-						</Text>
+                                                <Text style={[styles.tabText, selectedTab === "posts" && styles.activeTabText]}>
+                                                        {i18n.t("Restaurant.tabs.posts", { count: foodPosts.length })}
+                                                </Text>
 					</TouchableOpacity>
 					<TouchableOpacity
 						style={[styles.tab, selectedTab === "info" && styles.activeTab]}
 						onPress={() => setSelectedTab("info")}>
-						<Text style={[styles.tabText, selectedTab === "info" && styles.activeTabText]}>店舗情報</Text>
+                                                <Text style={[styles.tabText, selectedTab === "info" && styles.activeTabText]}>
+                                                        {i18n.t("Restaurant.tabs.info")}
+                                                </Text>
 					</TouchableOpacity>
 				</View>
 
@@ -340,16 +354,16 @@ export default function RestaurantScreen() {
 						<TouchableOpacity onPress={() => setShowFilter(false)}>
 							<X size={24} color="#000" />
 						</TouchableOpacity>
-						<Text style={styles.filterTitle}>フィルター</Text>
+                                                <Text style={styles.filterTitle}>{i18n.t("Restaurant.filter.title")}</Text>
 						<TouchableOpacity onPress={handleResetFilters}>
-							<Text style={styles.resetText}>リセット</Text>
+                                                        <Text style={styles.resetText}>{i18n.t("Restaurant.filter.reset")}</Text>
 						</TouchableOpacity>
 					</View>
 
 					<ScrollView style={styles.filterContent}>
 						{/* Price Range Filter */}
 						<View style={styles.filterSection}>
-							<Text style={styles.filterSectionTitle}>価格帯</Text>
+                                                        <Text style={styles.filterSectionTitle}>{i18n.t("Restaurant.filter.sections.priceRange")}</Text>
 							<View style={styles.filterOptions}>
 								{priceRanges.map((range) => (
 									<TouchableOpacity
@@ -375,7 +389,7 @@ export default function RestaurantScreen() {
 
 						{/* Category Filter */}
 						<View style={styles.filterSection}>
-							<Text style={styles.filterSectionTitle}>料理カテゴリ</Text>
+                                                        <Text style={styles.filterSectionTitle}>{i18n.t("Restaurant.filter.sections.category")}</Text>
 							<View style={styles.filterOptions}>
 								{categories.map((category) => (
 									<TouchableOpacity
@@ -402,7 +416,7 @@ export default function RestaurantScreen() {
 
 					<View style={styles.filterFooter}>
 						<TouchableOpacity style={styles.applyButton} onPress={handleApplyFilters}>
-							<Text style={styles.applyButtonText}>適用</Text>
+                                                        <Text style={styles.applyButtonText}>{i18n.t("Restaurant.filter.apply")}</Text>
 						</TouchableOpacity>
 					</View>
 				</SafeAreaView>

--- a/app-expo/app/(tabs)/map.tsx
+++ b/app-expo/app/(tabs)/map.tsx
@@ -23,7 +23,7 @@ import { useBlurModal } from "@/hooks/useBlurModal";
 import { Card } from "@/components/Card";
 import { PrimaryButton } from "@/components/PrimaryButton";
 import { ImageCardGrid } from "@/components/ImageCardGrid";
-import { i18n } from "@/lib/i18n";
+import i18n from "@/lib/i18n";
 import { ActiveBid, Review, mockActiveBids, mockReviews, mockBidHistory } from "@/features/map/constants";
 import { getBidStatusColor, getBidStatusText } from "@/features/map/utils";
 import Stars from "@/components/Stars";
@@ -258,8 +258,15 @@ export default function MapScreen() {
 
 						<View style={styles.bidAmountContainer}>
 							<Text style={styles.bidAmountLabel}>{i18n.t("Map.labels.currentBidAmount")}</Text>
-							<Text style={styles.bidAmount}>¥{selectedPlace.totalAmount.toLocaleString()}</Text>
-							<Text style={styles.remainingDays}>残り{selectedPlace.remainingDays}日</Text>
+                                                        <Text style={styles.bidAmount}>
+                                                                {i18n.t("Search.currencySuffix")}
+                                                                {selectedPlace.totalAmount.toLocaleString()}
+                                                        </Text>
+                                                        <Text style={styles.remainingDays}>
+                                                                {i18n.t("Common.daysRemaining", {
+                                                                        count: selectedPlace.remainingDays,
+                                                                })}
+                                                        </Text>
 						</View>
 
 						{/* Action Buttons */}
@@ -285,12 +292,16 @@ export default function MapScreen() {
 							<TouchableOpacity
 								style={[styles.tab, selectedTab === "reviews" && styles.activeTab]}
 								onPress={() => handleTabSelect("reviews")}>
-								<Text style={[styles.tabText, selectedTab === "reviews" && styles.activeTabText]}>レビュー</Text>
+                                                                <Text style={[styles.tabText, selectedTab === "reviews" && styles.activeTabText]}> 
+                                                                        {i18n.t("Map.tabs.reviews")}
+                                                                </Text>
 							</TouchableOpacity>
 							<TouchableOpacity
 								style={[styles.tab, selectedTab === "bids" && styles.activeTab]}
 								onPress={() => handleTabSelect("bids")}>
-								<Text style={[styles.tabText, selectedTab === "bids" && styles.activeTabText]}>入札</Text>
+                                                                <Text style={[styles.tabText, selectedTab === "bids" && styles.activeTabText]}> 
+                                                                        {i18n.t("Map.tabs.bids")}
+                                                                </Text>
 							</TouchableOpacity>
 						</View>
 
@@ -342,7 +353,10 @@ export default function MapScreen() {
 									filteredBidHistory.map((bid) => (
 										<View key={bid.id} style={styles.bidHistoryCard}>
 											<View style={styles.bidHistoryHeader}>
-												<Text style={styles.bidHistoryAmount}>¥{bid.amount.toLocaleString()}</Text>
+                                                                                                <Text style={styles.bidHistoryAmount}>
+                                                                                                        {i18n.t("Search.currencySuffix")}
+                                                                                                        {bid.amount.toLocaleString()}
+                                                                                                </Text>
 												<View
 													style={[
 														styles.bidStatusChip,
@@ -354,12 +368,16 @@ export default function MapScreen() {
 												</View>
 											</View>
 											<Text style={styles.bidHistoryDate}>{bid.date}</Text>
-											<Text style={styles.bidHistoryDays}>残り{bid.remainingDays}日</Text>
+                                                                                        <Text style={styles.bidHistoryDays}>
+                                                                                                {i18n.t("Common.daysRemaining", { count: bid.remainingDays })}
+                                                                                        </Text>
 										</View>
 									))
 								) : (
 									<View style={styles.emptyState}>
-										<Text style={styles.emptyStateText}>選択したステータスの入札がありません</Text>
+                                                                                <Text style={styles.emptyStateText}>
+                                                                                        {i18n.t("Map.emptyState.noBidsForStatus")}
+                                                                                </Text>
 									</View>
 								)}
 							</View>

--- a/app-expo/app/(tabs)/profile/index.tsx
+++ b/app-expo/app/(tabs)/profile/index.tsx
@@ -72,13 +72,18 @@ function DepositsScreen() {
 				/>
 				<View style={styles.depositInfo}>
 					<Text style={styles.depositRestaurantName}>{item.restaurantName}</Text>
-					<Text style={styles.depositAmount}>¥{item.bidAmount.toLocaleString()}</Text>
+                                    <Text style={styles.depositAmount}>
+                                            {i18n.t("Search.currencySuffix")}
+                                            {item.bidAmount.toLocaleString()}
+                                    </Text>
 				</View>
 				<View style={[styles.statusChip, { backgroundColor: getStatusColor(item.status) }]}>
 					<Text style={styles.statusText}>{getStatusText(item.status)}</Text>
 				</View>
 			</View>
-			<Text style={styles.depositDays}>残り{item.remainingDays}日</Text>
+                     <Text style={styles.depositDays}>
+                            {i18n.t("Common.daysRemaining", { count: item.remainingDays })}
+                     </Text>
 		</View>
 	);
 
@@ -98,11 +103,11 @@ function DepositsScreen() {
 	const getStatusText = (status: string) => {
 		switch (status) {
 			case "active":
-				return "アクティブ";
-			case "completed":
-				return "完了";
-			case "refunded":
-				return "返金済み";
+                                return i18n.t("Profile.statusLabels.active");
+                        case "completed":
+                                return i18n.t("Profile.statusLabels.completed");
+                        case "refunded":
+                                return i18n.t("Profile.statusLabels.refunded");
 			default:
 				return status;
 		}
@@ -211,7 +216,10 @@ function EarningsScreen() {
 					containerStyle={{ marginVertical: 16 }}
 					renderOverlay={(item) => (
 						<View style={styles.earningCardOverlay}>
-							<Text style={styles.earningCardAmount}>¥{item.earnings.toLocaleString()}</Text>
+                                                      <Text style={styles.earningCardAmount}>
+                                                              {i18n.t("Search.currencySuffix")}
+                                                              {item.earnings.toLocaleString()}
+                                                      </Text>
 							<View
 								style={[
 									styles.statusChip,
@@ -219,7 +227,11 @@ function EarningsScreen() {
 										backgroundColor: item.status === "paid" ? "#4CAF50" : "#FF9800",
 									},
 								]}>
-								<Text style={styles.statusText}>{item.status === "paid" ? "支払済み" : "保留中"}</Text>
+                                                                <Text style={styles.statusText}>
+                                                                        {item.status === "paid"
+                                                                                ? i18n.t("Profile.statusLabels.paid")
+                                                                                : i18n.t("Profile.statusLabels.pending")}
+                                                                </Text>
 							</View>
 						</View>
 					)}
@@ -418,15 +430,15 @@ export default function ProfileScreen() {
 						<View style={styles.statsContainer}>
 							<View style={styles.statColumn}>
 								<Text style={styles.statNumber}>{formatNumber(profile.followingCount)}</Text>
-								<Text style={styles.statLabel}>フォロー中</Text>
+                                                                <Text style={styles.statLabel}>{i18n.t("Profile.stats.following")}</Text>
 							</View>
 							<View style={styles.statColumn}>
 								<Text style={styles.statNumber}>{formatNumber(profile.followersCount)}</Text>
-								<Text style={styles.statLabel}>フォロワー</Text>
+                                                                <Text style={styles.statLabel}>{i18n.t("Profile.stats.followers")}</Text>
 							</View>
 							<View style={styles.statColumn}>
 								<Text style={styles.statNumber}>{formatNumber(profile.totalLikes)}</Text>
-								<Text style={styles.statLabel}>いいね</Text>
+                                                                <Text style={styles.statLabel}>{i18n.t("Profile.stats.likes")}</Text>
 							</View>
 						</View>
 					</View>
@@ -454,12 +466,14 @@ export default function ProfileScreen() {
 									style={[styles.followButton, isFollowing && styles.followingButton]}
 									onPress={handleFollow}>
 									<Text style={[styles.followButtonText, isFollowing && styles.followingButtonText]}>
-										{isFollowing ? "フォロー中" : "フォロー"}
+                                                                                {isFollowing
+                                                                                        ? i18n.t("Profile.buttons.following")
+                                                                                        : i18n.t("Profile.buttons.follow")}
 									</Text>
 								</TouchableOpacity>
 								<TouchableOpacity style={styles.messageButton}>
 									<MessageCircle size={16} color="#FFFFFF" />
-									<Text style={styles.messageButtonText}>メッセージ</Text>
+                                                                        <Text style={styles.messageButtonText}>{i18n.t("Profile.buttons.message")}</Text>
 								</TouchableOpacity>
 							</>
 						)}
@@ -486,7 +500,7 @@ export default function ProfileScreen() {
 						<View style={styles.privateContainer}>
 							<View style={styles.privateCard}>
 								<Lock size={48} color="#6B7280" />
-								<Text style={styles.privateText}>この内容は非公開です</Text>
+                                                                <Text style={styles.privateText}>{i18n.t("Profile.privateContent")}</Text>
 							</View>
 						</View>
 					) : (
@@ -510,7 +524,7 @@ export default function ProfileScreen() {
 			{/* Edit Profile Modal */}
 			<BlurModal animationType="slide" presentationStyle="pageSheet">
 				<Card>
-					<Text style={styles.editLabel}>自己紹介</Text>
+                                        <Text style={styles.editLabel}>{i18n.t("Profile.labels.bio")}</Text>
 					<TextInput
 						style={styles.editInput}
 						value={editedBio}

--- a/app-expo/components/FoodContentScreen.tsx
+++ b/app-expo/components/FoodContentScreen.tsx
@@ -114,7 +114,7 @@ export default function FoodContentScreen({ item }: FoodContentScreenProps) {
 				<View style={styles.headerLeft}>
 					<Text style={styles.menuName}>{item.name}</Text>
 					<View style={styles.priceRatingContainer}>
-						<Text style={styles.price}>¥2,800</Text>
+                                                <Text style={styles.price}>{i18n.t("Search.currencySuffix")}2,800</Text>
 						{/* <View style={styles.ratingContainer}>
               {renderStars(5, 4)}
               <Text style={styles.reviewCount}>(127)</Text>
@@ -129,7 +129,7 @@ export default function FoodContentScreen({ item }: FoodContentScreenProps) {
             style={styles.viewRestaurantButton}
             onPress={handleViewRestaurant}
           >
-            <Text style={styles.viewRestaurantButtonText}>店を見る</Text>
+            <Text style={styles.viewRestaurantButtonText}>{i18n.t("FoodContentScreen.buttons.viewRestaurant")}</Text>
           </TouchableOpacity> */}
 				</View>
 			</View>

--- a/app-expo/features/search/constants.ts
+++ b/app-expo/features/search/constants.ts
@@ -1,5 +1,5 @@
 // Constants and option data for the search feature
-import { i18n } from "@/lib/i18n";
+import i18n from "@/lib/i18n";
 
 export const timeSlots = [
 	{ id: "morning", label: "Search.timeSlots.morning", icon: "🌅" },
@@ -43,26 +43,26 @@ export const distanceOptions = [
 
 // Budget options in yen
 export const budgetOptions = [
-	{ value: null, label: "Search.labels.noMinBudget" },
-	{ value: 1000, label: "1,000¥" },
-	{ value: 2000, label: "2,000¥" },
-	{ value: 3000, label: "3,000¥" },
-	{ value: 4000, label: "4,000¥" },
-	{ value: 5000, label: "5,000¥" },
-	{ value: 6000, label: "6,000¥" },
-	{ value: 7000, label: "7,000¥" },
-	{ value: 8000, label: "8,000¥" },
-	{ value: 9000, label: "9,000¥" },
-	{ value: 10000, label: "10,000¥" },
-	{ value: 15000, label: "15,000¥" },
-	{ value: 20000, label: "20,000¥" },
-	{ value: 30000, label: "30,000¥" },
-	{ value: 40000, label: "40,000¥" },
-	{ value: 50000, label: "50,000¥" },
-	{ value: 60000, label: "60,000¥" },
-	{ value: 80000, label: "80,000¥" },
-	{ value: 100000, label: "100,000¥" },
-	{ value: null, label: "Search.labels.noMaxBudget" },
+        { value: null, label: "Search.labels.noMinBudget" },
+        { value: 1000, label: `1,000${i18n.t("Search.currencySuffix")}` },
+        { value: 2000, label: `2,000${i18n.t("Search.currencySuffix")}` },
+        { value: 3000, label: `3,000${i18n.t("Search.currencySuffix")}` },
+        { value: 4000, label: `4,000${i18n.t("Search.currencySuffix")}` },
+        { value: 5000, label: `5,000${i18n.t("Search.currencySuffix")}` },
+        { value: 6000, label: `6,000${i18n.t("Search.currencySuffix")}` },
+        { value: 7000, label: `7,000${i18n.t("Search.currencySuffix")}` },
+        { value: 8000, label: `8,000${i18n.t("Search.currencySuffix")}` },
+        { value: 9000, label: `9,000${i18n.t("Search.currencySuffix")}` },
+        { value: 10000, label: `10,000${i18n.t("Search.currencySuffix")}` },
+        { value: 15000, label: `15,000${i18n.t("Search.currencySuffix")}` },
+        { value: 20000, label: `20,000${i18n.t("Search.currencySuffix")}` },
+        { value: 30000, label: `30,000${i18n.t("Search.currencySuffix")}` },
+        { value: 40000, label: `40,000${i18n.t("Search.currencySuffix")}` },
+        { value: 50000, label: `50,000${i18n.t("Search.currencySuffix")}` },
+        { value: 60000, label: `60,000${i18n.t("Search.currencySuffix")}` },
+        { value: 80000, label: `80,000${i18n.t("Search.currencySuffix")}` },
+        { value: 100000, label: `100,000${i18n.t("Search.currencySuffix")}` },
+        { value: null, label: "Search.labels.noMaxBudget" },
 ];
 
 export const restrictionOptions = [

--- a/app-expo/hooks/useBlurModal.tsx
+++ b/app-expo/hooks/useBlurModal.tsx
@@ -4,7 +4,7 @@ import { BlurView } from "expo-blur";
 import { ScrollView } from "react-native";
 import { SafeAreaView, useSafeAreaInsets } from "react-native-safe-area-context";
 import { X } from "lucide-react-native";
-import { i18n } from "@/lib/i18n";
+import i18n from "@/lib/i18n";
 
 /* -------------------------------------------------------------------------- */
 /*                                Hook 定義                                   */

--- a/app-expo/locales/ar-SA.json
+++ b/app-expo/locales/ar-SA.json
@@ -9,8 +9,9 @@
 		"post": "نشر",
 		"processing": "معالجة...",
 		"error": "خطأ",
-		"success": "نجح"
-	},
+                "success": "نجح",
+                "daysRemaining": "متبقي {{count}} يومًا"
+        },
 	"Error": {
 		"maintenanceMessage": "نحن حالياً نقوم بأعمال صيانة.",
 		"unsupportedVersion": "هذا الإصدار لم يعد مدعومًا."
@@ -131,13 +132,16 @@
 			"viewCreatorProfile": "انتقل إلى ملف المُنشئ",
 			"reservation": "حجز"
 		},
-		"actions": {
-			"share": "مشاركة"
-		},
-		"info": {
-			"walkFromShibuya": "على بُعد 13 دقيقة سيرًا من محطة شيبويا"
-		}
-	},
+                "actions": {
+                        "share": "مشاركة"
+                },
+                "buttons": {
+                        "viewRestaurant": "عرض المطعم"
+                },
+                "info": {
+                        "walkFromShibuya": "على بُعد 13 دقيقة سيرًا من محطة شيبويا"
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "فتح تفاصيل العنصر"
 	},
@@ -161,20 +165,32 @@
 			"noDeposits": "لا توجد ودائع للحالة المحددة",
 			"noEarnings": "لا توجد أرباح للحالة المحددة"
 		},
-		"statusLabels": {
-			"active": "نشط",
-			"completed": "مكتمل",
-			"refunded": "مسترد",
-			"paid": "مدفوع",
-			"pending": "معلق"
-		},
-		"buttons": {
-			"editProfile": "تعديل الملف الشخصي"
-		},
-		"placeholders": {
-			"enterBio": "أدخل نبذة عنك..."
-		}
-	},
+                "statusLabels": {
+                        "active": "نشط",
+                        "completed": "مكتمل",
+                        "refunded": "مسترد",
+                        "paid": "مدفوع",
+                        "pending": "معلق"
+                },
+                "buttons": {
+                        "editProfile": "تعديل الملف الشخصي",
+                        "follow": "متابعة",
+                        "following": "متابَع",
+                        "message": "رسالة"
+                },
+                "stats": {
+                        "following": "يتابع",
+                        "followers": "متابعون",
+                        "likes": "إعجابات"
+                },
+                "labels": {
+                        "bio": "نبذة"
+                },
+                "privateContent": "هذا المحتوى خاص",
+                "placeholders": {
+                        "enterBio": "أدخل نبذة عنك..."
+                }
+        },
 	"NotFound": {
 		"title": "عذرًا!",
 		"message": "هذه الشاشة غير موجودة.",
@@ -201,23 +217,61 @@
 			"enterReview": "أدخل مراجعتك",
 			"enterBidAmount": "أدخل مبلغ العرض"
 		},
-		"labels": {
-			"endDate": "تاريخ الانتهاء:",
-			"paymentProcessing": "معالجة الدفع...",
-			"currentBidAmount": "مبلغ العرض الحالي"
-		},
-		"alerts": {
-			"locationError": "فشل في الحصول على معلومات الموقع",
-			"currentLocationError": "فشل في الحصول على الموقع الحالي",
-			"bidSuccess": "تم تقديم العرض بنجاح لـ {{place}} بمبلغ ¥{{amount}}",
-			"bidError": "فشل في تقديم العرض",
-			"reviewSuccess": "تم نشر المراجعة بنجاح",
-			"reviewError": "فشل في نشر المراجعة"
-		}
-	},
-	"Restaurant": {
-		"placeholders": {
-			"searchLocation": "البحث عن موقع/منطقة"
-		}
-	}
+                "labels": {
+                        "endDate": "تاريخ الانتهاء:",
+                        "paymentProcessing": "معالجة الدفع...",
+                        "currentBidAmount": "مبلغ العرض الحالي"
+                },
+                "tabs": {
+                        "reviews": "المراجعات",
+                        "bids": "العروض"
+                },
+                "emptyState": {
+                        "noBidsForStatus": "لا توجد عروض للحالة المحددة"
+                },
+                "alerts": {
+                        "locationError": "فشل في الحصول على معلومات الموقع",
+                        "currentLocationError": "فشل في الحصول على الموقع الحالي",
+                        "bidSuccess": "تم تقديم العرض بنجاح لـ {{place}} بمبلغ ¥{{amount}}",
+                        "bidError": "فشل في تقديم العرض",
+                        "reviewSuccess": "تم نشر المراجعة بنجاح",
+                        "reviewError": "فشل في نشر المراجعة"
+                }
+        },
+        "Restaurant": {
+                "placeholders": {
+                        "searchLocation": "البحث عن موقع/منطقة"
+                },
+                "buttons": {
+                        "reserve": "حجز",
+                        "postMedia": "نشر وسائط"
+                },
+                "tabs": {
+                        "posts": "منشورات {{count}}",
+                        "info": "معلومات"
+                },
+                "filter": {
+                        "title": "تصفية",
+                        "reset": "إعادة تعيين",
+                        "apply": "تطبيق",
+                        "sections": {
+                                "priceRange": "نطاق السعر",
+                                "category": "نوع المطبخ"
+                        },
+                        "priceRanges": {
+                                "under1000": "أقل من {{currency}}1,000",
+                                "range1000to3000": "{{currency}}1,000-3,000",
+                                "range3000to5000": "{{currency}}3,000-5,000",
+                                "over5000": "أكثر من {{currency}}5,000"
+                        },
+                        "categories": {
+                                "japanese": "ياباني",
+                                "italian": "إيطالي",
+                                "french": "فرنسي",
+                                "chinese": "صيني",
+                                "asian": "آسيوي",
+                                "other": "آخر"
+                        }
+                }
+        }
 }

--- a/app-expo/locales/en-US.json
+++ b/app-expo/locales/en-US.json
@@ -9,8 +9,9 @@
 		"post": "Post",
 		"processing": "Processing...",
 		"error": "Error",
-		"success": "Success"
-	},
+                "success": "Success",
+                "daysRemaining": "Remaining {{count}} days"
+        },
 	"Error": {
 		"maintenanceMessage": "We are currently undergoing maintenance.",
 		"unsupportedVersion": "This version is no longer supported."
@@ -131,13 +132,16 @@
 			"viewCreatorProfile": "Go to creator profile",
 			"reservation": "Reservation"
 		},
-		"actions": {
-			"share": "Share"
-		},
-		"info": {
-			"walkFromShibuya": "13 min walk from Shibuya Station"
-		}
-	},
+                "actions": {
+                        "share": "Share"
+                },
+                "buttons": {
+                        "viewRestaurant": "View restaurant"
+                },
+                "info": {
+                        "walkFromShibuya": "13 min walk from Shibuya Station"
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "Open item details"
 	},
@@ -161,20 +165,32 @@
 			"noDeposits": "No deposits for the selected status",
 			"noEarnings": "No earnings for the selected status"
 		},
-		"statusLabels": {
-			"active": "Active",
-			"completed": "Completed",
-			"refunded": "Refunded",
-			"paid": "Paid",
-			"pending": "Pending"
-		},
-		"buttons": {
-			"editProfile": "Edit Profile"
-		},
-		"placeholders": {
-			"enterBio": "Enter your bio..."
-		}
-	},
+                "statusLabels": {
+                        "active": "Active",
+                        "completed": "Completed",
+                        "refunded": "Refunded",
+                        "paid": "Paid",
+                        "pending": "Pending"
+                },
+                "buttons": {
+                        "editProfile": "Edit Profile",
+                        "follow": "Follow",
+                        "following": "Following",
+                        "message": "Message"
+                },
+                "stats": {
+                        "following": "Following",
+                        "followers": "Followers",
+                        "likes": "Likes"
+                },
+                "labels": {
+                        "bio": "Bio"
+                },
+                "privateContent": "This content is private",
+                "placeholders": {
+                        "enterBio": "Enter your bio..."
+                }
+        },
 	"NotFound": {
 		"title": "Oops!",
 		"message": "This screen doesn't exist.",
@@ -201,23 +217,61 @@
 			"enterReview": "Enter review",
 			"enterBidAmount": "Enter bid amount"
 		},
-		"labels": {
-			"endDate": "End date:",
-			"paymentProcessing": "Processing payment...",
-			"currentBidAmount": "Current bid amount"
-		},
-		"alerts": {
-			"locationError": "Failed to get location information",
-			"currentLocationError": "Failed to get current location",
-			"bidSuccess": "Bid placed successfully for {{place}} at ¥{{amount}}",
-			"bidError": "Failed to place bid",
-			"reviewSuccess": "Review posted successfully",
-			"reviewError": "Failed to post review"
-		}
-	},
-	"Restaurant": {
-		"placeholders": {
-			"searchLocation": "Search location/area"
-		}
-	}
+                "labels": {
+                        "endDate": "End date:",
+                        "paymentProcessing": "Processing payment...",
+                        "currentBidAmount": "Current bid amount"
+                },
+                "tabs": {
+                        "reviews": "Reviews",
+                        "bids": "Bids"
+                },
+                "emptyState": {
+                        "noBidsForStatus": "No bids for the selected status"
+                },
+                "alerts": {
+                        "locationError": "Failed to get location information",
+                        "currentLocationError": "Failed to get current location",
+                        "bidSuccess": "Bid placed successfully for {{place}} at ¥{{amount}}",
+                        "bidError": "Failed to place bid",
+                        "reviewSuccess": "Review posted successfully",
+                        "reviewError": "Failed to post review"
+                }
+        },
+        "Restaurant": {
+                "placeholders": {
+                        "searchLocation": "Search location/area"
+                },
+                "buttons": {
+                        "reserve": "Reserve",
+                        "postMedia": "Post media"
+                },
+                "tabs": {
+                        "posts": "Posts {{count}}",
+                        "info": "Info"
+                },
+                "filter": {
+                        "title": "Filter",
+                        "reset": "Reset",
+                        "apply": "Apply",
+                        "sections": {
+                                "priceRange": "Price range",
+                                "category": "Cuisine category"
+                        },
+                        "priceRanges": {
+                                "under1000": "Under {{currency}}1,000",
+                                "range1000to3000": "{{currency}}1,000-3,000",
+                                "range3000to5000": "{{currency}}3,000-5,000",
+                                "over5000": "Over {{currency}}5,000"
+                        },
+                        "categories": {
+                                "japanese": "Japanese",
+                                "italian": "Italian",
+                                "french": "French",
+                                "chinese": "Chinese",
+                                "asian": "Asian",
+                                "other": "Other"
+                        }
+                }
+        }
 }

--- a/app-expo/locales/es-ES.json
+++ b/app-expo/locales/es-ES.json
@@ -9,8 +9,9 @@
 		"post": "Publicar",
 		"processing": "Procesando...",
 		"error": "Error",
-		"success": "Éxito"
-	},
+                "success": "Éxito",
+                "daysRemaining": "Quedan {{count}} días"
+        },
 	"Error": {
 		"maintenanceMessage": "Actualmente estamos en mantenimiento.",
 		"unsupportedVersion": "Esta versión ya no es compatible."
@@ -131,13 +132,16 @@
 			"viewCreatorProfile": "Ver perfil del creador",
 			"reservation": "Reserva"
 		},
-		"actions": {
-			"share": "Compartir"
-		},
-		"info": {
-			"walkFromShibuya": "A 13 min a pie de la estación de Shibuya"
-		}
-	},
+                "actions": {
+                        "share": "Compartir"
+                },
+                "buttons": {
+                        "viewRestaurant": "Ver restaurante"
+                },
+                "info": {
+                        "walkFromShibuya": "A 13 min a pie de la estación de Shibuya"
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "Abrir detalles del elemento"
 	},
@@ -161,20 +165,32 @@
 			"noDeposits": "No hay depósitos para el estado seleccionado",
 			"noEarnings": "No hay ganancias para el estado seleccionado"
 		},
-		"statusLabels": {
-			"active": "Activo",
-			"completed": "Completado",
-			"refunded": "Reembolsado",
-			"paid": "Pagado",
-			"pending": "Pendiente"
-		},
-		"buttons": {
-			"editProfile": "Editar Perfil"
-		},
-		"placeholders": {
-			"enterBio": "Ingresa tu biografía..."
-		}
-	},
+                "statusLabels": {
+                        "active": "Activo",
+                        "completed": "Completado",
+                        "refunded": "Reembolsado",
+                        "paid": "Pagado",
+                        "pending": "Pendiente"
+                },
+                "buttons": {
+                        "editProfile": "Editar Perfil",
+                        "follow": "Seguir",
+                        "following": "Siguiendo",
+                        "message": "Mensaje"
+                },
+                "stats": {
+                        "following": "Siguiendo",
+                        "followers": "Seguidores",
+                        "likes": "Me gusta"
+                },
+                "labels": {
+                        "bio": "Bio"
+                },
+                "privateContent": "Este contenido es privado",
+                "placeholders": {
+                        "enterBio": "Ingresa tu biografía..."
+                }
+        },
 	"NotFound": {
 		"title": "¡Vaya!",
 		"message": "Esta pantalla no existe.",
@@ -201,23 +217,61 @@
 			"enterReview": "Ingresa tu reseña",
 			"enterBidAmount": "Ingresa el monto de la oferta"
 		},
-		"labels": {
-			"endDate": "Fecha de fin:",
-			"paymentProcessing": "Procesando pago...",
-			"currentBidAmount": "Monto de oferta actual"
-		},
-		"alerts": {
-			"locationError": "Error al obtener información de ubicación",
-			"currentLocationError": "Error al obtener ubicación actual",
-			"bidSuccess": "Oferta realizada exitosamente para {{place}} por ¥{{amount}}",
-			"bidError": "Error al realizar la oferta",
-			"reviewSuccess": "Reseña publicada exitosamente",
-			"reviewError": "Error al publicar la reseña"
-		}
-	},
-	"Restaurant": {
-		"placeholders": {
-			"searchLocation": "Buscar ubicación/área"
-		}
-	}
+                "labels": {
+                        "endDate": "Fecha de fin:",
+                        "paymentProcessing": "Procesando pago...",
+                        "currentBidAmount": "Monto de oferta actual"
+                },
+                "tabs": {
+                        "reviews": "Reseñas",
+                        "bids": "Ofertas"
+                },
+                "emptyState": {
+                        "noBidsForStatus": "No hay ofertas para el estado seleccionado"
+                },
+                "alerts": {
+                        "locationError": "Error al obtener información de ubicación",
+                        "currentLocationError": "Error al obtener ubicación actual",
+                        "bidSuccess": "Oferta realizada exitosamente para {{place}} por ¥{{amount}}",
+                        "bidError": "Error al realizar la oferta",
+                        "reviewSuccess": "Reseña publicada exitosamente",
+                        "reviewError": "Error al publicar la reseña"
+                }
+        },
+        "Restaurant": {
+                "placeholders": {
+                        "searchLocation": "Buscar ubicación/área"
+                },
+                "buttons": {
+                        "reserve": "Reservar",
+                        "postMedia": "Publicar multimedia"
+                },
+                "tabs": {
+                        "posts": "Publicaciones {{count}}",
+                        "info": "Información"
+                },
+                "filter": {
+                        "title": "Filtrar",
+                        "reset": "Restablecer",
+                        "apply": "Aplicar",
+                        "sections": {
+                                "priceRange": "Rango de precios",
+                                "category": "Categoría"
+                        },
+                        "priceRanges": {
+                                "under1000": "Menos de {{currency}}1,000",
+                                "range1000to3000": "{{currency}}1,000-3,000",
+                                "range3000to5000": "{{currency}}3,000-5,000",
+                                "over5000": "Más de {{currency}}5,000"
+                        },
+                        "categories": {
+                                "japanese": "Japonesa",
+                                "italian": "Italiana",
+                                "french": "Francesa",
+                                "chinese": "China",
+                                "asian": "Asiática",
+                                "other": "Otra"
+                        }
+                }
+        }
 }

--- a/app-expo/locales/fr-FR.json
+++ b/app-expo/locales/fr-FR.json
@@ -9,8 +9,9 @@
 		"post": "Publier",
 		"processing": "Traitement...",
 		"error": "Erreur",
-		"success": "Succès"
-	},
+                "success": "Succès",
+                "daysRemaining": "Il reste {{count}} jours"
+        },
 	"Error": {
 		"maintenanceMessage": "Nous sommes actuellement en maintenance.",
 		"unsupportedVersion": "Cette version n'est plus prise en charge."
@@ -131,13 +132,16 @@
 			"viewCreatorProfile": "Voir le profil du créateur",
 			"reservation": "Réservation"
 		},
-		"actions": {
-			"share": "Partager"
-		},
-		"info": {
-			"walkFromShibuya": "À 13 min à pied de la gare de Shibuya"
-		}
-	},
+                "actions": {
+                        "share": "Partager"
+                },
+                "buttons": {
+                        "viewRestaurant": "Voir le restaurant"
+                },
+                "info": {
+                        "walkFromShibuya": "À 13 min à pied de la gare de Shibuya"
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "Ouvrir les détails de l'article"
 	},
@@ -161,20 +165,32 @@
 			"noDeposits": "Aucun dépôt pour le statut sélectionné",
 			"noEarnings": "Aucun revenu pour le statut sélectionné"
 		},
-		"statusLabels": {
-			"active": "Actif",
-			"completed": "Terminé",
-			"refunded": "Remboursé",
-			"paid": "Payé",
-			"pending": "En attente"
-		},
-		"buttons": {
-			"editProfile": "Modifier le profil"
-		},
-		"placeholders": {
-			"enterBio": "Entrez votre biographie..."
-		}
-	},
+                "statusLabels": {
+                        "active": "Actif",
+                        "completed": "Terminé",
+                        "refunded": "Remboursé",
+                        "paid": "Payé",
+                        "pending": "En attente"
+                },
+                "buttons": {
+                        "editProfile": "Modifier le profil",
+                        "follow": "Suivre",
+                        "following": "Suivi",
+                        "message": "Message"
+                },
+                "stats": {
+                        "following": "Abonnements",
+                        "followers": "Abonnés",
+                        "likes": "J'aime"
+                },
+                "labels": {
+                        "bio": "Bio"
+                },
+                "privateContent": "Ce contenu est privé",
+                "placeholders": {
+                        "enterBio": "Entrez votre biographie..."
+                }
+        },
 	"NotFound": {
 		"title": "Oups !",
 		"message": "Cet écran n'existe pas.",
@@ -201,23 +217,61 @@
 			"enterReview": "Entrez votre avis",
 			"enterBidAmount": "Entrez le montant de l'enchère"
 		},
-		"labels": {
-			"endDate": "Date de fin:",
-			"paymentProcessing": "Traitement du paiement...",
-			"currentBidAmount": "Montant de l'enchère actuelle"
-		},
-		"alerts": {
-			"locationError": "Échec de l'obtention des informations de localisation",
-			"currentLocationError": "Échec de l'obtention de la position actuelle",
-			"bidSuccess": "Enchère placée avec succès pour {{place}} à ¥{{amount}}",
-			"bidError": "Échec du placement de l'enchère",
-			"reviewSuccess": "Avis publié avec succès",
-			"reviewError": "Échec de la publication de l'avis"
-		}
-	},
-	"Restaurant": {
-		"placeholders": {
-			"searchLocation": "Rechercher un lieu/région"
-		}
-	}
+                "labels": {
+                        "endDate": "Date de fin:",
+                        "paymentProcessing": "Traitement du paiement...",
+                        "currentBidAmount": "Montant de l'enchère actuelle"
+                },
+                "tabs": {
+                        "reviews": "Avis",
+                        "bids": "Enchères"
+                },
+                "emptyState": {
+                        "noBidsForStatus": "Aucune enchère pour l'état sélectionné"
+                },
+                "alerts": {
+                        "locationError": "Échec de l'obtention des informations de localisation",
+                        "currentLocationError": "Échec de l'obtention de la position actuelle",
+                        "bidSuccess": "Enchère placée avec succès pour {{place}} à ¥{{amount}}",
+                        "bidError": "Échec du placement de l'enchère",
+                        "reviewSuccess": "Avis publié avec succès",
+                        "reviewError": "Échec de la publication de l'avis"
+                }
+        },
+        "Restaurant": {
+                "placeholders": {
+                        "searchLocation": "Rechercher un lieu/région"
+                },
+                "buttons": {
+                        "reserve": "Réserver",
+                        "postMedia": "Publier des médias"
+                },
+                "tabs": {
+                        "posts": "Publications {{count}}",
+                        "info": "Infos"
+                },
+                "filter": {
+                        "title": "Filtrer",
+                        "reset": "Réinitialiser",
+                        "apply": "Appliquer",
+                        "sections": {
+                                "priceRange": "Tranche de prix",
+                                "category": "Type de cuisine"
+                        },
+                        "priceRanges": {
+                                "under1000": "Moins de {{currency}}1 000",
+                                "range1000to3000": "{{currency}}1 000-3 000",
+                                "range3000to5000": "{{currency}}3 000-5 000",
+                                "over5000": "Plus de {{currency}}5 000"
+                        },
+                        "categories": {
+                                "japanese": "Japonaise",
+                                "italian": "Italienne",
+                                "french": "Française",
+                                "chinese": "Chinoise",
+                                "asian": "Asiatique",
+                                "other": "Autre"
+                        }
+                }
+        }
 }

--- a/app-expo/locales/hi-IN.json
+++ b/app-expo/locales/hi-IN.json
@@ -9,8 +9,9 @@
 		"post": "पोस्ट करें",
 		"processing": "प्रसंस्करण...",
 		"error": "त्रुटि",
-		"success": "सफलता"
-	},
+                "success": "सफलता",
+                "daysRemaining": "{{count}} दिन शेष"
+        },
 	"Error": {
 		"maintenanceMessage": "हम वर्तमान में रखरखाव कर रहे हैं।",
 		"unsupportedVersion": "यह संस्करण अब समर्थित नहीं है।"
@@ -131,13 +132,16 @@
 			"viewCreatorProfile": "निर्माता की प्रोफ़ाइल पर जाएँ",
 			"reservation": "आरक्षण"
 		},
-		"actions": {
-			"share": "साझा करें"
-		},
-		"info": {
-			"walkFromShibuya": "शिबुया स्टेशन से 13 मिनट की पैदल दूरी"
-		}
-	},
+                "actions": {
+                        "share": "साझा करें"
+                },
+                "buttons": {
+                        "viewRestaurant": "रेस्टोरेंट देखें"
+                },
+                "info": {
+                        "walkFromShibuya": "शिबुया स्टेशन से 13 मिनट की पैदल दूरी"
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "आइटम विवरण खोलें"
 	},
@@ -161,20 +165,32 @@
 			"noDeposits": "चयनित स्थिति के लिए कोई जमा नहीं",
 			"noEarnings": "चयनित स्थिति के लिए कोई आय नहीं"
 		},
-		"statusLabels": {
-			"active": "सक्रिय",
-			"completed": "पूर्ण",
-			"refunded": "धनवापसी",
-			"paid": "भुगतान किया गया",
-			"pending": "लंबित"
-		},
-		"buttons": {
-			"editProfile": "प्रोफ़ाइल संपादित करें"
-		},
-		"placeholders": {
-			"enterBio": "अपना परिचय दर्ज करें..."
-		}
-	},
+                "statusLabels": {
+                        "active": "सक्रिय",
+                        "completed": "पूर्ण",
+                        "refunded": "धनवापसी",
+                        "paid": "भुगतान किया गया",
+                        "pending": "लंबित"
+                },
+                "buttons": {
+                        "editProfile": "प्रोफ़ाइल संपादित करें",
+                        "follow": "फ़ॉलो",
+                        "following": "फ़ॉलो कर रहे हैं",
+                        "message": "संदेश"
+                },
+                "stats": {
+                        "following": "अनुसरण",
+                        "followers": "अनुयायी",
+                        "likes": "पसंद"
+                },
+                "labels": {
+                        "bio": "परिचय"
+                },
+                "privateContent": "यह सामग्री निजी है",
+                "placeholders": {
+                        "enterBio": "अपना परिचय दर्ज करें..."
+                }
+        },
 	"NotFound": {
 		"title": "ओह!",
 		"message": "यह स्क्रीन मौजूद नहीं है।",
@@ -201,23 +217,61 @@
 			"enterReview": "समीक्षा दर्ज करें",
 			"enterBidAmount": "बोली राशि दर्ज करें"
 		},
-		"labels": {
-			"endDate": "समाप्ति तिथि:",
-			"paymentProcessing": "भुगतान प्रसंस्करण...",
-			"currentBidAmount": "वर्तमान बोली राशि"
-		},
-		"alerts": {
-			"locationError": "स्थान जानकारी प्राप्त करने में विफल",
-			"currentLocationError": "वर्तमान स्थान प्राप्त करने में विफल",
-			"bidSuccess": "{{place}} के लिए ¥{{amount}} में सफलतापूर्वक बोली लगाई गई",
-			"bidError": "बोली लगाने में विफल",
-			"reviewSuccess": "समीक्षा सफलतापूर्वक पोस्ट की गई",
-			"reviewError": "समीक्षा पोस्ट करने में विफल"
-		}
-	},
-	"Restaurant": {
-		"placeholders": {
-			"searchLocation": "स्थान/क्षेत्र खोजें"
-		}
-	}
+                "labels": {
+                        "endDate": "समाप्ति तिथि:",
+                        "paymentProcessing": "भुगतान प्रसंस्करण...",
+                        "currentBidAmount": "वर्तमान बोली राशि"
+                },
+                "tabs": {
+                        "reviews": "समीक्षाएँ",
+                        "bids": "बोली"
+                },
+                "emptyState": {
+                        "noBidsForStatus": "चयनित स्थिति के लिए कोई बोली नहीं"
+                },
+                "alerts": {
+                        "locationError": "स्थान जानकारी प्राप्त करने में विफल",
+                        "currentLocationError": "वर्तमान स्थान प्राप्त करने में विफल",
+                        "bidSuccess": "{{place}} के लिए ¥{{amount}} में सफलतापूर्वक बोली लगाई गई",
+                        "bidError": "बोली लगाने में विफल",
+                        "reviewSuccess": "समीक्षा सफलतापूर्वक पोस्ट की गई",
+                        "reviewError": "समीक्षा पोस्ट करने में विफल"
+                }
+        },
+        "Restaurant": {
+                "placeholders": {
+                        "searchLocation": "स्थान/क्षेत्र खोजें"
+                },
+                "buttons": {
+                        "reserve": "आरक्षण",
+                        "postMedia": "मीडिया पोस्ट करें"
+                },
+                "tabs": {
+                        "posts": "पोस्ट {{count}}",
+                        "info": "जानकारी"
+                },
+                "filter": {
+                        "title": "फ़िल्टर",
+                        "reset": "रीसेट",
+                        "apply": "लागू करें",
+                        "sections": {
+                                "priceRange": "मूल्य सीमा",
+                                "category": "भोजन श्रेणी"
+                        },
+                        "priceRanges": {
+                                "under1000": "{{currency}}1,000 से कम",
+                                "range1000to3000": "{{currency}}1,000-3,000",
+                                "range3000to5000": "{{currency}}3,000-5,000",
+                                "over5000": "{{currency}}5,000 से अधिक"
+                        },
+                        "categories": {
+                                "japanese": "जापानी",
+                                "italian": "इतालवी",
+                                "french": "फ़्रेंच",
+                                "chinese": "चीनी",
+                                "asian": "एशियाई",
+                                "other": "अन्य"
+                        }
+                }
+        }
 }

--- a/app-expo/locales/ja-JP.json
+++ b/app-expo/locales/ja-JP.json
@@ -9,8 +9,9 @@
 		"post": "投稿",
 		"processing": "処理中...",
 		"error": "エラー",
-		"success": "成功"
-	},
+                "success": "成功",
+                "daysRemaining": "残り{{count}}日"
+        },
 	"Error": {
 		"maintenanceMessage": "ただいまメンテナンス中です。",
 		"unsupportedVersion": "古いバージョンのため利用できません。"
@@ -131,13 +132,16 @@
 			"viewCreatorProfile": "投稿者プロフィールへ",
 			"reservation": "予約"
 		},
-		"actions": {
-			"share": "シェア"
-		},
-		"info": {
-			"walkFromShibuya": "渋谷駅から徒歩13分"
-		}
-	},
+                "actions": {
+                        "share": "シェア"
+                },
+                "buttons": {
+                        "viewRestaurant": "店を見る"
+                },
+                "info": {
+                        "walkFromShibuya": "渋谷駅から徒歩13分"
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "詳細を表示"
 	},
@@ -161,20 +165,32 @@
 			"noDeposits": "選択したステータスの入札がありません",
 			"noEarnings": "選択したステータスの収益がありません"
 		},
-		"statusLabels": {
-			"active": "アクティブ",
-			"completed": "完了",
-			"refunded": "返金済み",
-			"paid": "支払済み",
-			"pending": "保留中"
-		},
-		"buttons": {
-			"editProfile": "プロフィールを編集"
-		},
-		"placeholders": {
-			"enterBio": "自己紹介を入力してください..."
-		}
-	},
+                "statusLabels": {
+                        "active": "アクティブ",
+                        "completed": "完了",
+                        "refunded": "返金済み",
+                        "paid": "支払済み",
+                        "pending": "保留中"
+                },
+                "buttons": {
+                        "editProfile": "プロフィールを編集",
+                        "follow": "フォロー",
+                        "following": "フォロー中",
+                        "message": "メッセージ"
+                },
+                "stats": {
+                        "following": "フォロー中",
+                        "followers": "フォロワー",
+                        "likes": "いいね"
+                },
+                "labels": {
+                        "bio": "自己紹介"
+                },
+                "privateContent": "この内容は非公開です",
+                "placeholders": {
+                        "enterBio": "自己紹介を入力してください..."
+                }
+        },
 	"NotFound": {
 		"title": "おっと！",
 		"message": "この画面は存在しません。",
@@ -201,23 +217,61 @@
 			"enterReview": "レビューを入力",
 			"enterBidAmount": "入札額を入力"
 		},
-		"labels": {
-			"endDate": "終了日:",
-			"paymentProcessing": "決済処理中...",
-			"currentBidAmount": "現在の入札額"
-		},
-		"alerts": {
-			"locationError": "位置情報の取得に失敗しました",
-			"currentLocationError": "現在地の取得に失敗しました",
-			"bidSuccess": "{{place}}に¥{{amount}}で入札しました",
-			"bidError": "入札に失敗しました",
-			"reviewSuccess": "レビューを投稿しました",
-			"reviewError": "レビューの投稿に失敗しました"
-		}
-	},
-	"Restaurant": {
-		"placeholders": {
-			"searchLocation": "地点・地域を検索"
-		}
-	}
+                "labels": {
+                        "endDate": "終了日:",
+                        "paymentProcessing": "決済処理中...",
+                        "currentBidAmount": "現在の入札額"
+                },
+                "tabs": {
+                        "reviews": "レビュー",
+                        "bids": "入札"
+                },
+                "emptyState": {
+                        "noBidsForStatus": "選択したステータスの入札がありません"
+                },
+                "alerts": {
+                        "locationError": "位置情報の取得に失敗しました",
+                        "currentLocationError": "現在地の取得に失敗しました",
+                        "bidSuccess": "{{place}}に¥{{amount}}で入札しました",
+                        "bidError": "入札に失敗しました",
+                        "reviewSuccess": "レビューを投稿しました",
+                        "reviewError": "レビューの投稿に失敗しました"
+                }
+        },
+        "Restaurant": {
+                "placeholders": {
+                        "searchLocation": "地点・地域を検索"
+                },
+                "buttons": {
+                        "reserve": "予約する",
+                        "postMedia": "画像・動画投稿"
+                },
+                "tabs": {
+                        "posts": "投稿 {{count}}",
+                        "info": "店舗情報"
+                },
+                "filter": {
+                        "title": "フィルター",
+                        "reset": "リセット",
+                        "apply": "適用",
+                        "sections": {
+                                "priceRange": "価格帯",
+                                "category": "料理カテゴリ"
+                        },
+                        "priceRanges": {
+                                "under1000": "1,000{{currency}}以下",
+                                "range1000to3000": "1,000-3,000{{currency}}",
+                                "range3000to5000": "3,000-5,000{{currency}}",
+                                "over5000": "5,000{{currency}}以上"
+                        },
+                        "categories": {
+                                "japanese": "和食",
+                                "italian": "イタリアン",
+                                "french": "フレンチ",
+                                "chinese": "中華",
+                                "asian": "アジア料理",
+                                "other": "その他"
+                        }
+                }
+        }
 }

--- a/app-expo/locales/ko-KR.json
+++ b/app-expo/locales/ko-KR.json
@@ -9,8 +9,9 @@
 		"post": "게시",
 		"processing": "처리 중...",
 		"error": "오류",
-		"success": "성공"
-	},
+                "success": "성공",
+                "daysRemaining": "남은 {{count}}일"
+        },
 	"Error": {
 		"maintenanceMessage": "현재 점검 중입니다.",
 		"unsupportedVersion": "이 버전은 더 이상 지원되지 않습니다."
@@ -131,13 +132,16 @@
 			"viewCreatorProfile": "작성자 프로필로 이동",
 			"reservation": "예약"
 		},
-		"actions": {
-			"share": "공유하기"
-		},
-		"info": {
-			"walkFromShibuya": "시부야역에서 도보 13분"
-		}
-	},
+                "actions": {
+                        "share": "공유하기"
+                },
+                "buttons": {
+                        "viewRestaurant": "가게 보기"
+                },
+                "info": {
+                        "walkFromShibuya": "시부야역에서 도보 13분"
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "항목 세부정보 열기"
 	},
@@ -161,20 +165,32 @@
 			"noDeposits": "선택한 상태에 대한 예치금이 없습니다",
 			"noEarnings": "선택한 상태에 대한 수익이 없습니다"
 		},
-		"statusLabels": {
-			"active": "활성",
-			"completed": "완료",
-			"refunded": "환불됨",
-			"paid": "지불됨",
-			"pending": "보류 중"
-		},
-		"buttons": {
-			"editProfile": "프로필 편집"
-		},
-		"placeholders": {
-			"enterBio": "자기소개를 입력하세요..."
-		}
-	},
+                "statusLabels": {
+                        "active": "활성",
+                        "completed": "완료",
+                        "refunded": "환불됨",
+                        "paid": "지불됨",
+                        "pending": "보류 중"
+                },
+                "buttons": {
+                        "editProfile": "프로필 편집",
+                        "follow": "팔로우",
+                        "following": "팔로잉",
+                        "message": "메시지"
+                },
+                "stats": {
+                        "following": "팔로잉",
+                        "followers": "팔로워",
+                        "likes": "좋아요"
+                },
+                "labels": {
+                        "bio": "자기소개"
+                },
+                "privateContent": "이 내용은 비공개입니다",
+                "placeholders": {
+                        "enterBio": "자기소개를 입력하세요..."
+                }
+        },
 	"NotFound": {
 		"title": "이런!",
 		"message": "이 화면은 존재하지 않습니다.",
@@ -201,23 +217,61 @@
 			"enterReview": "리뷰 입력",
 			"enterBidAmount": "입찰 금액 입력"
 		},
-		"labels": {
-			"endDate": "종료일:",
-			"paymentProcessing": "결제 처리 중...",
-			"currentBidAmount": "현재 입찰 금액"
-		},
-		"alerts": {
-			"locationError": "위치 정보 가져오기 실패",
-			"currentLocationError": "현재 위치 가져오기 실패",
-			"bidSuccess": "{{place}}에 ¥{{amount}}로 입찰 성공",
-			"bidError": "입찰 실패",
-			"reviewSuccess": "리뷰 게시 성공",
-			"reviewError": "리뷰 게시 실패"
-		}
-	},
-	"Restaurant": {
-		"placeholders": {
-			"searchLocation": "위치/지역 검색"
-		}
-	}
+                "labels": {
+                        "endDate": "종료일:",
+                        "paymentProcessing": "결제 처리 중...",
+                        "currentBidAmount": "현재 입찰 금액"
+                },
+                "tabs": {
+                        "reviews": "리뷰",
+                        "bids": "입찰"
+                },
+                "emptyState": {
+                        "noBidsForStatus": "선택한 상태의 입찰이 없습니다"
+                },
+                "alerts": {
+                        "locationError": "위치 정보 가져오기 실패",
+                        "currentLocationError": "현재 위치 가져오기 실패",
+                        "bidSuccess": "{{place}}에 ¥{{amount}}로 입찰 성공",
+                        "bidError": "입찰 실패",
+                        "reviewSuccess": "리뷰 게시 성공",
+                        "reviewError": "리뷰 게시 실패"
+                }
+        },
+        "Restaurant": {
+                "placeholders": {
+                        "searchLocation": "위치/지역 검색"
+                },
+                "buttons": {
+                        "reserve": "예약하기",
+                        "postMedia": "미디어 게시"
+                },
+                "tabs": {
+                        "posts": "게시물 {{count}}",
+                        "info": "정보"
+                },
+                "filter": {
+                        "title": "필터",
+                        "reset": "초기화",
+                        "apply": "적용",
+                        "sections": {
+                                "priceRange": "가격대",
+                                "category": "카테고리"
+                        },
+                        "priceRanges": {
+                                "under1000": "{{currency}}1,000 이하",
+                                "range1000to3000": "{{currency}}1,000-3,000",
+                                "range3000to5000": "{{currency}}3,000-5,000",
+                                "over5000": "{{currency}}5,000 이상"
+                        },
+                        "categories": {
+                                "japanese": "일식",
+                                "italian": "이탈리아식",
+                                "french": "프랑스식",
+                                "chinese": "중식",
+                                "asian": "아시아 요리",
+                                "other": "기타"
+                        }
+                }
+        }
 }

--- a/app-expo/locales/zh-CN.json
+++ b/app-expo/locales/zh-CN.json
@@ -9,8 +9,9 @@
 		"post": "发布",
 		"processing": "处理中...",
 		"error": "错误",
-		"success": "成功"
-	},
+                "success": "成功",
+                "daysRemaining": "剩余{{count}}天"
+        },
 	"Error": {
 		"maintenanceMessage": "当前正在维护中。",
 		"unsupportedVersion": "此版本已不再受支持."
@@ -131,13 +132,16 @@
 			"viewCreatorProfile": "查看创作者资料",
 			"reservation": "预订"
 		},
-		"actions": {
-			"share": "分享"
-		},
-		"info": {
-			"walkFromShibuya": "距离涩谷站步行13分钟"
-		}
-	},
+                "actions": {
+                        "share": "分享"
+                },
+                "buttons": {
+                        "viewRestaurant": "查看餐厅"
+                },
+                "info": {
+                        "walkFromShibuya": "距离涩谷站步行13分钟"
+                }
+        },
 	"ImageCardGrid": {
 		"openItemDetails": "打开项目详情"
 	},
@@ -161,20 +165,32 @@
 			"noDeposits": "所选状态没有存款",
 			"noEarnings": "所选状态没有收益"
 		},
-		"statusLabels": {
-			"active": "活跃",
-			"completed": "已完成",
-			"refunded": "已退款",
-			"paid": "已支付",
-			"pending": "待定"
-		},
-		"buttons": {
-			"editProfile": "编辑个人资料"
-		},
-		"placeholders": {
-			"enterBio": "请输入您的个人简介..."
-		}
-	},
+                "statusLabels": {
+                        "active": "活跃",
+                        "completed": "已完成",
+                        "refunded": "已退款",
+                        "paid": "已支付",
+                        "pending": "待定"
+                },
+                "buttons": {
+                        "editProfile": "编辑个人资料",
+                        "follow": "关注",
+                        "following": "已关注",
+                        "message": "消息"
+                },
+                "stats": {
+                        "following": "关注中",
+                        "followers": "粉丝",
+                        "likes": "点赞"
+                },
+                "labels": {
+                        "bio": "简介"
+                },
+                "privateContent": "此内容为私密",
+                "placeholders": {
+                        "enterBio": "请输入您的个人简介..."
+                }
+        },
 	"NotFound": {
 		"title": "哎呀！",
 		"message": "此屏幕不存在。",
@@ -201,23 +217,61 @@
 			"enterReview": "输入评论",
 			"enterBidAmount": "输入出价金额"
 		},
-		"labels": {
-			"endDate": "结束日期:",
-			"paymentProcessing": "付款处理中...",
-			"currentBidAmount": "当前出价金额"
-		},
-		"alerts": {
-			"locationError": "获取位置信息失败",
-			"currentLocationError": "获取当前位置失败",
-			"bidSuccess": "成功为{{place}}出价¥{{amount}}",
-			"bidError": "出价失败",
-			"reviewSuccess": "评论发布成功",
-			"reviewError": "评论发布失败"
-		}
-	},
-	"Restaurant": {
-		"placeholders": {
-			"searchLocation": "搜索地点/区域"
-		}
-	}
+                "labels": {
+                        "endDate": "结束日期:",
+                        "paymentProcessing": "付款处理中...",
+                        "currentBidAmount": "当前出价金额"
+                },
+                "tabs": {
+                        "reviews": "评论",
+                        "bids": "出价"
+                },
+                "emptyState": {
+                        "noBidsForStatus": "所选状态没有出价"
+                },
+                "alerts": {
+                        "locationError": "获取位置信息失败",
+                        "currentLocationError": "获取当前位置失败",
+                        "bidSuccess": "成功为{{place}}出价¥{{amount}}",
+                        "bidError": "出价失败",
+                        "reviewSuccess": "评论发布成功",
+                        "reviewError": "评论发布失败"
+                }
+        },
+        "Restaurant": {
+                "placeholders": {
+                        "searchLocation": "搜索地点/区域"
+                },
+                "buttons": {
+                        "reserve": "预订",
+                        "postMedia": "发布媒体"
+                },
+                "tabs": {
+                        "posts": "帖子 {{count}}",
+                        "info": "信息"
+                },
+                "filter": {
+                        "title": "筛选",
+                        "reset": "重置",
+                        "apply": "应用",
+                        "sections": {
+                                "priceRange": "价格范围",
+                                "category": "菜系"
+                        },
+                        "priceRanges": {
+                                "under1000": "{{currency}}1,000 以下",
+                                "range1000to3000": "{{currency}}1,000-3,000",
+                                "range3000to5000": "{{currency}}3,000-5,000",
+                                "over5000": "{{currency}}5,000 以上"
+                        },
+                        "categories": {
+                                "japanese": "日本菜",
+                                "italian": "意大利菜",
+                                "french": "法餐",
+                                "chinese": "中餐",
+                                "asian": "亚洲菜",
+                                "other": "其他"
+                        }
+                }
+        }
 }


### PR DESCRIPTION
## Summary
- replace hardcoded UI strings with i18n lookups
- add missing translation keys for map, restaurant, profile, and shared labels
- localize currency labels and remaining days messaging

## Testing
- `pnpm --filter app-expo lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `pnpm --filter app-expo typecheck`
- `pnpm --filter app-expo test -- --watchAll=false` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894926cf7e0832ba382894e6242b884